### PR TITLE
chore: bump corepc-node from 22_1 to 23_2

### DIFF
--- a/src/crates/primitives/Cargo.toml
+++ b/src/crates/primitives/Cargo.toml
@@ -8,7 +8,7 @@ sled = "0.34"
 bitcoin_slices = { version = "0.10.0", features = ["bitcoin"] }
 bitcoin = { workspace = true }
 anyhow = { version = "1.0", optional = true }
-corepc-node = { version = "0.10", features = ["download", "22_1"], optional = true }
+corepc-node = { version = "0.10", features = ["download", "23_2"], optional = true }
 
 [features]
 test-utils = ["dep:anyhow", "dep:corepc-node"]
@@ -17,7 +17,7 @@ test-utils = ["dep:anyhow", "dep:corepc-node"]
 tempfile = "3"
 anyhow = "1.0"
 bitcoin-test-data = "0.2.0"
-corepc-node = { version = "0.10", features = ["download", "22_1"] }
+corepc-node = { version = "0.10", features = ["download", "23_2"] }
 criterion = "0.5"
 
 [[bench]]


### PR DESCRIPTION
Fix arm64 macOS download failure by bumping corepc-node from 22_1 to 23_2. Bitcoin Core 22.1 has no arm64 macOS binary.

Closes #13 