### PR TITLE
Remove --lib flag from CI test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-cargo-
       
       - name: Run unit tests
-        run: cargo test --lib --no-fail-fast
+        run: cargo test --no-fail-fast
 
   bench:
     name: Bench Suite


### PR DESCRIPTION
The root workspace has no `src/lib.rs`, causing "no library targets found" error. Using `cargo test --no-fail-fast` tests all crates in the workspace