### PR TITLE
Expose script_pubkey_bytes on TxOutHandle

### DIFF
--- a/src/crates/primitives/src/handle.rs
+++ b/src/crates/primitives/src/handle.rs
@@ -4,8 +4,8 @@ use crate::{
         abstract_fingerprints::HasNLockTime,
         abstract_types::{
             AbstractTransaction, AbstractTxIn, AbstractTxOut, EnumerateInputValueInArbitraryOrder,
-            EnumerateOutputValueInArbitraryOrder, EnumerateSpentTxOuts, HasSequence, OutputCount,
-            TxConstituent,
+            EnumerateOutputValueInArbitraryOrder, EnumerateSpentTxOuts, HasScriptPubkey,
+            HasSequence, OutputCount, TxConstituent,
         },
         graph_index::IndexedGraph,
     },
@@ -106,6 +106,12 @@ impl<'a> TxOutHandle<'a> {
     // TODO: seperate methods
     fn output_data(&self) -> (bitcoin::Amount, crate::ScriptPubkeyHash) {
         self.index.tx_out_data(&self.out_id)
+    }
+}
+
+impl<'a> HasScriptPubkey for TxOutHandle<'a> {
+    fn script_pubkey_bytes(&self) -> Vec<u8> {
+        self.index.tx_out_spk_bytes(&self.out_id)
     }
 }
 
@@ -235,6 +241,10 @@ impl<'a> AbstractTxOut for TxOutHandle<'a> {
     fn script_pubkey_hash(&self) -> crate::ScriptPubkeyHash {
         let (_value, spk_hash) = self.output_data();
         spk_hash
+    }
+
+    fn script_pubkey_bytes(&self) -> Vec<u8> {
+        HasScriptPubkey::script_pubkey_bytes(self)
     }
 }
 

--- a/src/crates/primitives/src/loose/mod.rs
+++ b/src/crates/primitives/src/loose/mod.rs
@@ -320,4 +320,18 @@ impl TxOutDataIndex for InMemoryIndex {
             .expect("txout should be present if index is built correctly");
         (output.value(), output.script_pubkey_hash())
     }
+
+    fn tx_out_spk_bytes(&self, out_id: &AnyOutId) -> Vec<u8> {
+        let loose_out = out_id
+            .loose_id()
+            .expect("loose storage only supports loose outids");
+        let tx = self
+            .txs
+            .get(&loose_out.txid())
+            .expect("loose txid not found in storage");
+        let output = tx
+            .output_at(loose_out.vout() as usize)
+            .expect("txout should be present if index is built correctly");
+        output.script_pubkey_bytes()
+    }
 }

--- a/src/crates/primitives/src/test_utils/mod.rs
+++ b/src/crates/primitives/src/test_utils/mod.rs
@@ -88,6 +88,11 @@ impl AbstractTxOut for DummyTxOutData {
     fn script_pubkey_hash(&self) -> ScriptPubkeyHash {
         self.spk_hash
     }
+
+    fn script_pubkey_bytes(&self) -> Vec<u8> {
+        // TODO: enrich with real script bytes
+        vec![]
+    }
 }
 
 impl AbstractTransaction for DummyTxData {

--- a/src/crates/primitives/src/traits/abstract_types.rs
+++ b/src/crates/primitives/src/traits/abstract_types.rs
@@ -44,6 +44,8 @@ pub trait AbstractTxOut {
     /// Returns the script pubkey hash (20-byte hash) if available
     /// Returns None if the script doesn't contain a standard hash or is not supported
     fn script_pubkey_hash(&self) -> ScriptPubkeyHash;
+    /// Returns the full scriptPubKey bytes
+    fn script_pubkey_bytes(&self) -> Vec<u8>;
 }
 
 /// Trait for transaction looking things. Generic over the ids as they can be either loose or dense.

--- a/src/crates/primitives/src/traits/graph_index.rs
+++ b/src/crates/primitives/src/traits/graph_index.rs
@@ -43,6 +43,7 @@ pub trait OutpointIndex {
 
 pub trait TxOutDataIndex {
     fn tx_out_data(&self, out_id: &AnyOutId) -> (Amount, ScriptPubkeyHash);
+    fn tx_out_spk_bytes(&self, out_id: &AnyOutId) -> Vec<u8>;
 }
 
 pub trait IndexedGraph:

--- a/src/crates/primitives/src/unified/mod.rs
+++ b/src/crates/primitives/src/unified/mod.rs
@@ -617,6 +617,33 @@ impl TxOutDataIndex for UnifiedStorage {
         let spk_hash = script_pubkey_hash(&txout.script_pubkey);
         (txout.value, spk_hash)
     }
+
+    fn tx_out_spk_bytes(&self, out_id: &AnyOutId) -> Vec<u8> {
+        if let Some(loose_outid) = out_id.loose_id() {
+            let loose = self
+                .loose
+                .as_ref()
+                .expect("loose storage missing for loose outid");
+            let tx = loose
+                .txs
+                .get(&loose_outid.txid())
+                .expect("loose txid not found in storage");
+            let output = tx
+                .output_at(loose_outid.vout() as usize)
+                .expect("txout should be present if index is built correctly");
+            return output.script_pubkey_bytes();
+        }
+
+        let dense_outid = out_id
+            .confirmed_id()
+            .expect("confirmed outid must map to dense outid");
+        let dense = self
+            .dense
+            .as_ref()
+            .expect("dense storage missing for confirmed outid");
+        let txout = dense.get_txout(dense_outid);
+        txout.script_pubkey.to_bytes()
+    }
 }
 
 impl IndexedGraph for UnifiedStorage {}


### PR DESCRIPTION
required to correctly classify P2TR, OP_RETURN, and segwit outputs in coinjoin detection

adds `script_pubkey_bytes()` to `AbstractTxOut` and implements it in both storages, enabling `TxOutHandle` to implement `HasScriptPubkey` and automatically gain `output_type()` via the blanket impl in fingerprints

`DummyTxOutData` returns empty bytes for now

coded with big pickle assistance

part of #5 