### PR TITLE
Add InputCount trait and input_len to AbstractTransaction

### DIFF
--- a/src/crates/primitives/src/handle.rs
+++ b/src/crates/primitives/src/handle.rs
@@ -5,7 +5,7 @@ use crate::{
         abstract_types::{
             AbstractTransaction, AbstractTxIn, AbstractTxOut, EnumerateInputValueInArbitraryOrder,
             EnumerateOutputValueInArbitraryOrder, EnumerateSpentTxOuts, HasScriptPubkey,
-            HasSequence, OutputCount, TxConstituent,
+            HasSequence, InputCount, OutputCount, TxConstituent,
         },
         graph_index::IndexedGraph,
     },
@@ -167,6 +167,10 @@ impl<'a> EnumerateOutputValueInArbitraryOrder for TxHandle<'a> {
 }
 
 impl<'a> AbstractTransaction for TxHandle<'a> {
+    fn input_len(&self) -> usize {
+        self.index.tx_in_ids(&self.tx_id).len()
+    }
+
     fn inputs(&self) -> Box<dyn Iterator<Item = Box<dyn AbstractTxIn + '_>> + '_> {
         let input_ids = self.index.tx_in_ids(&self.tx_id);
         let inputs: Vec<_> = input_ids
@@ -261,6 +265,12 @@ impl<'a> EnumerateInputValueInArbitraryOrder for TxHandle<'a> {
 impl<'a> OutputCount for TxHandle<'a> {
     fn output_count(&self) -> usize {
         self.output_len()
+    }
+}
+
+impl<'a> InputCount for TxHandle<'a> {
+    fn input_count(&self) -> usize {
+        self.input_len()
     }
 }
 

--- a/src/crates/primitives/src/loose/mod.rs
+++ b/src/crates/primitives/src/loose/mod.rs
@@ -258,7 +258,7 @@ impl TxIoIndex for InMemoryIndex {
             .txs
             .get(&loose_txid)
             .expect("loose txid not found in storage");
-        let input_len = tx.inputs().count();
+        let input_len = tx.input_len();
         (0..input_len)
             .map(|vin| AnyInId::from(TxInId::new(loose_txid, vin as u32)))
             .collect()

--- a/src/crates/primitives/src/test_utils/mod.rs
+++ b/src/crates/primitives/src/test_utils/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     traits::HasNLockTime,
     traits::abstract_types::{
         AbstractTransaction, AbstractTxIn, AbstractTxOut, EnumerateOutputValueInArbitraryOrder,
-        EnumerateSpentTxOuts, OutputCount, TxConstituent,
+        EnumerateSpentTxOuts, InputCount, OutputCount, TxConstituent,
     },
 };
 
@@ -121,6 +121,10 @@ impl AbstractTransaction for DummyTxData {
         Box::new(outputs.into_iter())
     }
 
+    fn input_len(&self) -> usize {
+        self.spent_coins.len()
+    }
+
     fn output_len(&self) -> usize {
         self.outputs.len()
     }
@@ -139,6 +143,12 @@ impl AbstractTransaction for DummyTxData {
 impl OutputCount for DummyTxData {
     fn output_count(&self) -> usize {
         self.outputs.len()
+    }
+}
+
+impl InputCount for DummyTxData {
+    fn input_count(&self) -> usize {
+        self.spent_coins.len()
     }
 }
 

--- a/src/crates/primitives/src/traits/abstract_types.rs
+++ b/src/crates/primitives/src/traits/abstract_types.rs
@@ -14,6 +14,10 @@ pub trait OutputCount: AbstractTransaction {
     fn output_count(&self) -> usize;
 }
 
+pub trait InputCount: AbstractTransaction {
+    fn input_count(&self) -> usize;
+}
+
 pub trait EnumerateSpentTxOuts: AbstractTransaction {
     fn spent_coins(&self) -> impl Iterator<Item = AnyOutId>;
 }
@@ -54,6 +58,8 @@ pub trait AbstractTransaction {
     fn inputs(&self) -> Box<dyn Iterator<Item = Box<dyn AbstractTxIn + '_>> + '_>;
     /// Returns an iterator over transaction outputs
     fn outputs(&self) -> Box<dyn Iterator<Item = Box<dyn AbstractTxOut + '_>> + '_>;
+    /// Returns the number of inputs
+    fn input_len(&self) -> usize;
     /// Returns the number of outputs
     fn output_len(&self) -> usize;
     /// Returns the output at the given index, if it exists

--- a/src/crates/primitives/src/traits/mod.rs
+++ b/src/crates/primitives/src/traits/mod.rs
@@ -4,7 +4,7 @@ pub mod graph_index;
 
 pub use abstract_fingerprints::HasNLockTime;
 pub use abstract_types::{
-    HasPrevOutput, HasScriptPubkey, HasSequence, HasValue, HasVersion, HasWitnessData,
+    HasPrevOutput, HasScriptPubkey, HasSequence, HasValue, HasVersion, HasWitnessData, InputCount,
 };
 
 use crate::ScriptPubkeyHash;

--- a/src/crates/primitives/src/unified/mod.rs
+++ b/src/crates/primitives/src/unified/mod.rs
@@ -457,7 +457,7 @@ impl TxIoIndex for UnifiedStorage {
                 .txs
                 .get(&loose_txid)
                 .expect("loose txid not found in storage");
-            let input_len = tx.inputs().count();
+            let input_len = tx.input_len();
             return (0..input_len)
                 .map(|vin| AnyInId::from(loose::TxInId::new(loose_txid, vin as u32)))
                 .collect();


### PR DESCRIPTION
adds `InputCount` trait following the existing `OutputCount` pattern, and `input_len` as a required method on AbstractTransaction.

needed to express `inputs >= ceil(n_equal_outputs / 2)` in the joinmarket detector 

also migrates callers from `inputs().count()` to `input_len()` for consistence with `output_len()` and as an optimization 

part of #5 