### PR TITLE
Split TxOutDataIndex to use separate methods

### DIFF
--- a/src/crates/heuristics/src/ast/uih.rs
+++ b/src/crates/heuristics/src/ast/uih.rs
@@ -12,10 +12,7 @@ use tx_indexer_pipeline::{
     node::{Node, NodeId},
     value::{TxMask, TxOutSet, TxSet},
 };
-use tx_indexer_primitives::{
-    AbstractTxOut,
-    unified::{AnyOutId, AnyTxId},
-};
+use tx_indexer_primitives::unified::{AnyOutId, AnyTxId};
 
 use crate::uih::UnnecessaryInputHeuristic;
 

--- a/src/crates/primitives/src/handle.rs
+++ b/src/crates/primitives/src/handle.rs
@@ -102,15 +102,18 @@ impl<'a> TxOutHandle<'a> {
             })
     }
 
-    // TODO: seperate methods
-    fn output_data(&self) -> (bitcoin::Amount, crate::ScriptPubkeyHash) {
-        self.index.tx_out_data(&self.out_id)
+    pub fn value(&self) -> bitcoin::Amount {
+        self.index.value(&self.out_id)
+    }
+
+    pub fn script_pubkey_hash(&self) -> crate::ScriptPubkeyHash {
+        self.index.script_pubkey_hash(&self.out_id)
     }
 }
 
 impl<'a> HasScriptPubkey for TxOutHandle<'a> {
     fn script_pubkey_bytes(&self) -> Vec<u8> {
-        self.index.tx_out_spk_bytes(&self.out_id)
+        self.index.script_pubkey_bytes(&self.out_id)
     }
 }
 
@@ -246,13 +249,11 @@ impl<'a> AbstractTxIn for TxInHandle<'a> {
 
 impl<'a> AbstractTxOut for TxOutHandle<'a> {
     fn value(&self) -> bitcoin::Amount {
-        let (value, _spk_hash) = self.output_data();
-        value
+        TxOutHandle::value(self)
     }
 
     fn script_pubkey_hash(&self) -> crate::ScriptPubkeyHash {
-        let (_value, spk_hash) = self.output_data();
-        spk_hash
+        TxOutHandle::script_pubkey_hash(self)
     }
 
     fn script_pubkey_bytes(&self) -> Vec<u8> {

--- a/src/crates/primitives/src/loose/mod.rs
+++ b/src/crates/primitives/src/loose/mod.rs
@@ -6,6 +6,7 @@ use crate::traits::graph_index::{
 use crate::{
     AnyInId, AnyOutId, AnyTxId, ScriptPubkeyHash, traits::abstract_types::AbstractTransaction,
 };
+use bitcoin::Amount;
 
 use std::{
     collections::HashMap,
@@ -307,7 +308,7 @@ impl OutpointIndex for InMemoryIndex {
 }
 
 impl TxOutDataIndex for InMemoryIndex {
-    fn tx_out_data(&self, out_id: &AnyOutId) -> (bitcoin::Amount, ScriptPubkeyHash) {
+    fn value(&self, out_id: &AnyOutId) -> Amount {
         let loose_out = out_id
             .loose_id()
             .expect("loose storage only supports loose outids");
@@ -318,10 +319,24 @@ impl TxOutDataIndex for InMemoryIndex {
         let output = tx
             .output_at(loose_out.vout() as usize)
             .expect("txout should be present if index is built correctly");
-        (output.value(), output.script_pubkey_hash())
+        output.value()
     }
 
-    fn tx_out_spk_bytes(&self, out_id: &AnyOutId) -> Vec<u8> {
+    fn script_pubkey_hash(&self, out_id: &AnyOutId) -> ScriptPubkeyHash {
+        let loose_out = out_id
+            .loose_id()
+            .expect("loose storage only supports loose outids");
+        let tx = self
+            .txs
+            .get(&loose_out.txid())
+            .expect("loose txid not found in storage");
+        let output = tx
+            .output_at(loose_out.vout() as usize)
+            .expect("txout should be present if index is built correctly");
+        output.script_pubkey_hash()
+    }
+
+    fn script_pubkey_bytes(&self, out_id: &AnyOutId) -> Vec<u8> {
         let loose_out = out_id
             .loose_id()
             .expect("loose storage only supports loose outids");

--- a/src/crates/primitives/src/traits/graph_index.rs
+++ b/src/crates/primitives/src/traits/graph_index.rs
@@ -42,8 +42,9 @@ pub trait OutpointIndex {
 }
 
 pub trait TxOutDataIndex {
-    fn tx_out_data(&self, out_id: &AnyOutId) -> (Amount, ScriptPubkeyHash);
-    fn tx_out_spk_bytes(&self, out_id: &AnyOutId) -> Vec<u8>;
+    fn value(&self, out_id: &AnyOutId) -> Amount;
+    fn script_pubkey_hash(&self, out_id: &AnyOutId) -> ScriptPubkeyHash;
+    fn script_pubkey_bytes(&self, out_id: &AnyOutId) -> Vec<u8>;
 }
 
 pub trait IndexedGraph:

--- a/src/crates/primitives/src/unified/mod.rs
+++ b/src/crates/primitives/src/unified/mod.rs
@@ -8,6 +8,7 @@ use crate::traits::graph_index::{
 };
 use crate::{ScriptPubkeyHash, dense, loose, traits::abstract_types::AbstractTransaction};
 use crate::{dense::build_indices, loose::LooseIndexBuilder, sled::spk_db::SledScriptPubkeyDb};
+use bitcoin::Amount;
 use std::{ops::Range, path::PathBuf};
 
 #[repr(transparent)]
@@ -590,7 +591,7 @@ impl OutpointIndex for UnifiedStorage {
 }
 
 impl TxOutDataIndex for UnifiedStorage {
-    fn tx_out_data(&self, out_id: &AnyOutId) -> (bitcoin::Amount, ScriptPubkeyHash) {
+    fn value(&self, out_id: &AnyOutId) -> Amount {
         if let Some(loose_outid) = out_id.loose_id() {
             let loose = self
                 .loose
@@ -603,7 +604,7 @@ impl TxOutDataIndex for UnifiedStorage {
             let output = tx
                 .output_at(loose_outid.vout() as usize)
                 .expect("txout should be present if index is built correctly");
-            return (output.value(), output.script_pubkey_hash());
+            return output.value();
         }
 
         let dense_outid = out_id
@@ -614,11 +615,37 @@ impl TxOutDataIndex for UnifiedStorage {
             .as_ref()
             .expect("dense storage missing for confirmed outid");
         let txout = dense.get_txout(dense_outid);
-        let spk_hash = script_pubkey_hash(&txout.script_pubkey);
-        (txout.value, spk_hash)
+        txout.value
     }
 
-    fn tx_out_spk_bytes(&self, out_id: &AnyOutId) -> Vec<u8> {
+    fn script_pubkey_hash(&self, out_id: &AnyOutId) -> ScriptPubkeyHash {
+        if let Some(loose_outid) = out_id.loose_id() {
+            let loose = self
+                .loose
+                .as_ref()
+                .expect("loose storage missing for loose outid");
+            let tx = loose
+                .txs
+                .get(&loose_outid.txid())
+                .expect("loose txid not found in storage");
+            let output = tx
+                .output_at(loose_outid.vout() as usize)
+                .expect("txout should be present if index is built correctly");
+            return output.script_pubkey_hash();
+        }
+
+        let dense_outid = out_id
+            .confirmed_id()
+            .expect("confirmed outid must map to dense outid");
+        let dense = self
+            .dense
+            .as_ref()
+            .expect("dense storage missing for confirmed outid");
+        let txout = dense.get_txout(dense_outid);
+        script_pubkey_hash(&txout.script_pubkey)
+    }
+
+    fn script_pubkey_bytes(&self, out_id: &AnyOutId) -> Vec<u8> {
         if let Some(loose_outid) = out_id.loose_id() {
             let loose = self
                 .loose


### PR DESCRIPTION
split `TxOutDataIndex` into separate methods

 addressing https://github.com/payjoin/tx-indexer/pull/18/changes#r2988118371

coded with big picke assistance 