### PR TITLE
Migrate fingerprint binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,9 @@ name = "bitcoin-transaction-indexer"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
+ "hex",
+ "serde_json",
+ "tx-indexer-fingerprints",
  "tx-indexer-heuristics",
  "tx-indexer-pipeline",
  "tx-indexer-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,15 @@ members = [
 [workspace.dependencies]
 bitcoin = { version = "0.32.0", features = ["rand"] }
 
+[[bin]]
+name = "fingerprint"
+path = "bin/fingerprint.rs"
+
 [dependencies]
 tx-indexer-primitives = { path = "src/crates/primitives" }
 tx-indexer-heuristics = { path = "src/crates/heuristics" }
 tx-indexer-pipeline = { path = "src/crates/pipeline" }
+tx-indexer-fingerprints = { path = "src/crates/fingerprints" }
 bitcoin = { workspace = true }
+hex = "0.4"
+serde_json = "1"

--- a/bin/fingerprint.rs
+++ b/bin/fingerprint.rs
@@ -1,0 +1,173 @@
+use bitcoin::Transaction;
+use bitcoin::consensus::Decodable;
+use serde_json::{Value, json};
+use tx_indexer_fingerprints::types::{InputSortingType, OutputStructureType, OutputType};
+use tx_indexer_fingerprints::{input, input_with_prevout, output, transaction};
+use tx_indexer_primitives::HasVersion;
+
+fn decode_tx(hex_str: &str) -> Result<Transaction, String> {
+    let bytes = hex::decode(hex_str).map_err(|e| format!("Invalid hex: {e}"))?;
+    Transaction::consensus_decode(&mut bytes.as_slice())
+        .map_err(|e| format!("Invalid transaction: {e}"))
+}
+
+fn output_type_str(t: &OutputType) -> &'static str {
+    match t {
+        OutputType::OpReturn => "op_return",
+        OutputType::NonStandard => "non_standard",
+        OutputType::P2pkh => "p2pkh",
+        OutputType::P2sh => "p2sh",
+        OutputType::P2wpkh => "p2wpkh",
+        OutputType::P2wsh => "p2wsh",
+        OutputType::P2tr => "p2tr",
+    }
+}
+
+fn input_order_str(t: &InputSortingType) -> &'static str {
+    match t {
+        InputSortingType::Single => "single",
+        InputSortingType::Ascending => "ascending",
+        InputSortingType::Descending => "descending",
+        InputSortingType::Bip69 => "bip69",
+        InputSortingType::Historical => "historical",
+        InputSortingType::Unknown => "unknown",
+    }
+}
+
+fn output_structure_str(t: &OutputStructureType) -> &'static str {
+    match t {
+        OutputStructureType::Single => "single",
+        OutputStructureType::Double => "double",
+        OutputStructureType::Multi => "multi",
+        OutputStructureType::Bip69 => "bip69",
+    }
+}
+
+fn fingerprint_spending_tx(tx: &Transaction) -> Value {
+    let inputs: Vec<Value> = tx
+        .input
+        .iter()
+        .map(|txin| {
+            json!({
+                "signals_rbf": input::signals_rbf(txin),
+                "low_r_grinding": input::low_r_grinding(txin),
+            })
+        })
+        .collect();
+
+    let outputs: Vec<Value> = tx
+        .output
+        .iter()
+        .map(|txout| {
+            json!({
+                "type": output_type_str(&output::output_type(txout)),
+            })
+        })
+        .collect();
+
+    json!({
+        "version": tx.version(),
+        "signals_rbf": transaction::tx_signals_rbf(&tx.input),
+        "anti_fee_snipe": transaction::anti_fee_snipe(tx.lock_time.to_consensus_u32()),
+        "output_structure": transaction::output_structure(&tx.output).iter().map(output_structure_str).collect::<Vec<_>>(),
+        "inputs": inputs,
+        "outputs": outputs,
+    })
+}
+
+fn fingerprint_with_prevouts(tx: &Transaction, prev_outs: &[bitcoin::TxOut]) -> Value {
+    let inputs: Vec<Value> = tx
+        .input
+        .iter()
+        .zip(prev_outs.iter())
+        .map(|(txin, prevout)| {
+            json!({
+                "signals_rbf": input::signals_rbf(txin),
+                "low_r_grinding": input::low_r_grinding(txin),
+                "input_type": output_type_str(&input_with_prevout::input_type(prevout)),
+                "has_uncompressed_pubkey": input_with_prevout::has_uncompressed_pubkey(txin, prevout),
+                "taproot_keyspend_non_default_sighash": input_with_prevout::taproot_keyspend_non_default_sighash(txin, prevout),
+            })
+        })
+        .collect();
+
+    let outputs: Vec<Value> = tx
+        .output
+        .iter()
+        .map(|txout| {
+            json!({
+                "type": output_type_str(&output::output_type(txout)),
+            })
+        })
+        .collect();
+
+    json!({
+        "version": tx.version(),
+        "signals_rbf": transaction::tx_signals_rbf(&tx.input),
+        "anti_fee_snipe": transaction::anti_fee_snipe(tx.lock_time.to_consensus_u32()),
+        "output_structure": transaction::output_structure(&tx.output).iter().map(output_structure_str).collect::<Vec<_>>(),
+        "address_reuse": transaction::address_reuse(&tx.output, prev_outs),
+        "mixed_input_types": transaction::mixed_input_types(prev_outs),
+        "input_order": transaction::input_order(&tx.input, prev_outs).iter().map(input_order_str).collect::<Vec<_>>(),
+        "inputs": inputs,
+        "outputs": outputs,
+    })
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <tx_hex> [prev_tx_hex...]", args[0]);
+        eprintln!();
+        eprintln!("  tx_hex       Hex-encoded raw Bitcoin transaction to fingerprint");
+        eprintln!("  prev_tx_hex  Hex-encoded raw previous transactions (one per input)");
+        std::process::exit(1);
+    }
+
+    let tx = match decode_tx(&args[1]) {
+        Ok(tx) => tx,
+        Err(e) => {
+            eprintln!("Error decoding transaction: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let output = if args.len() < 3 {
+        fingerprint_spending_tx(&tx)
+    } else {
+        let prev_txs: Vec<Transaction> = args[2..]
+            .iter()
+            .enumerate()
+            .map(|(i, hex)| match decode_tx(hex) {
+                Ok(tx) => tx,
+                Err(e) => {
+                    eprintln!("Error decoding prev transaction #{}: {e}", i + 1);
+                    std::process::exit(1);
+                }
+            })
+            .collect();
+
+        let prev_outs: Vec<bitcoin::TxOut> = tx
+            .input
+            .iter()
+            .map(|txin| {
+                prev_txs
+                    .iter()
+                    .find(|prev_tx| prev_tx.compute_txid() == txin.previous_output.txid)
+                    .unwrap_or_else(|| {
+                        eprintln!(
+                            "Error: no prev tx found for input outpoint {}",
+                            txin.previous_output
+                        );
+                        std::process::exit(1);
+                    })
+                    .output[txin.previous_output.vout as usize]
+                    .clone()
+            })
+            .collect();
+
+        fingerprint_with_prevouts(&tx, &prev_outs)
+    };
+
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+}


### PR DESCRIPTION
from https://github.com/arminsabouri/rust-wallet-fingerprints

This is a good starting point. Follow up work will include newer fingerprints this project collects . 

Example: 
```bash
 cargo run --bin fingerprint (curl https://mempool.space/testnet/api/tx/4e123785c6aecd9f321d2c7a63bd58083fee49ab3c39be84330edb45a98a8a3f/hex) | jq .
```

```json
{
  "anti_fee_snipe": true,
  "inputs": [
    {
      "low_r_grinding": false,
      "signals_rbf": true
    },
    {
      "low_r_grinding": false,
      "signals_rbf": true
    }
  ],
  "output_structure": [
    "double",
    "bip69"
  ],
  "outputs": [
    {
      "type": "p2wpkh",
    },
    {
      "type": "p2wpkh",
    }
  ],
  "signals_rbf": true,
  "version": 2
}
```

cc @bc1cindy 