### PR TITLE
Remove unused new DummyTxOutData constructor

### DIFF
--- a/src/crates/primitives/src/test_utils/mod.rs
+++ b/src/crates/primitives/src/test_utils/mod.rs
@@ -64,14 +64,6 @@ pub struct DummyTxOutData {
 }
 
 impl DummyTxOutData {
-    pub fn new(value: u64, vout: u32) -> Self {
-        Self {
-            value,
-            vout,
-            script_pubkey: vec![],
-        }
-    }
-
     /// Create a new DummyTxOutData with a given amount and a dummy script pubkey
     pub fn new_with_amount(amount: u64, vout: u32) -> Self {
         Self {


### PR DESCRIPTION
I noticed using `grep -rn "DummyTxOutData::new(" .` and `grep -rn "DummyTxOutData::new(" src/` that we're not using the new constructor anymore, so I'm removing it to keep a clean code.