### PR TITLE
Encapsulate DummyTxData fields behind constructors

### DIFF
--- a/src/crates/heuristics/src/ast/same_address.rs
+++ b/src/crates/heuristics/src/ast/same_address.rs
@@ -83,38 +83,38 @@ mod tests {
         let unique_spk2 = [2u8; 20];
 
         // Coinbase 1
-        let coinbase1 = DummyTxData {
-            outputs: vec![DummyTxOutData::new_with_script(10_000, 0, unique_spk1)],
-            spent_coins: vec![],
-            n_locktime: 0,
-        };
+        let coinbase1 = DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_script(
+            10_000,
+            0,
+            unique_spk1,
+        )]);
 
         // Coinbase 2
-        let coinbase2 = DummyTxData {
-            outputs: vec![DummyTxOutData::new_with_script(10_000, 0, unique_spk2)],
-            spent_coins: vec![],
-            n_locktime: 0,
-        };
+        let coinbase2 = DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_script(
+            10_000,
+            0,
+            unique_spk2,
+        )]);
 
         // Spend coinbase 1, make payment + change (change spk is shared)
-        let spend1 = DummyTxData {
-            spent_coins: vec![TxOutId::new(TxId(1), 0)],
-            outputs: vec![
+        let spend1 = DummyTxData::new(
+            vec![
                 DummyTxOutData::new_with_script(4_000, 0, unique_spk1), // payment
                 DummyTxOutData::new_with_script(5_000, 1, shared_spk), // change (shared with spend2)
             ],
-            n_locktime: 0,
-        };
+            vec![TxOutId::new(TxId(1), 0)],
+            0,
+        );
 
         // Spend coinbase 2, make payment + change (change spk is shared)
-        let spend2 = DummyTxData {
-            spent_coins: vec![TxOutId::new(TxId(2), 0)],
-            outputs: vec![
+        let spend2 = DummyTxData::new(
+            vec![
                 DummyTxOutData::new_with_script(4_000, 0, unique_spk2), // payment
                 DummyTxOutData::new_with_script(5_000, 1, shared_spk), // change (shared with spend1)
             ],
-            n_locktime: 0,
-        };
+            vec![TxOutId::new(TxId(2), 0)],
+            0,
+        );
 
         vec![
             Arc::new(coinbase1),

--- a/src/crates/heuristics/src/ast/tests.rs
+++ b/src/crates/heuristics/src/ast/tests.rs
@@ -23,35 +23,27 @@ pub(crate) mod tests {
 
     impl TestFixture {
         pub fn spending_tx() -> DummyTxData {
-            DummyTxData {
-                outputs: vec![
+            DummyTxData::new(
+                vec![
                     // Payment output
                     DummyTxOutData::new_with_amount(100, 0),
                     // Change output
                     DummyTxOutData::new_with_amount(150, 1),
                 ],
-                spent_coins: vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                n_locktime: 0,
-            }
+                vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+                0,
+            )
         }
 
         pub fn coinbase1() -> DummyTxData {
-            DummyTxData {
-                outputs: vec![
-                    DummyTxOutData::new_with_amount(100, 0),
-                    DummyTxOutData::new_with_amount(150, 1),
-                ],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }
+            DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(100, 0),
+                DummyTxOutData::new_with_amount(150, 1),
+            ])
         }
 
         pub fn coinbase2() -> DummyTxData {
-            DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(150, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }
+            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(150, 0)])
         }
 
         pub fn payment_output() -> TxOutId {
@@ -64,14 +56,14 @@ pub(crate) mod tests {
 
         /// Single-input spending tx (spends coinbase2). Used for UIH2 single-input tests.
         pub fn single_input_spending_tx() -> DummyTxData {
-            DummyTxData {
-                outputs: vec![
+            DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(200, 0),
                     DummyTxOutData::new_with_amount(300, 1),
                 ],
-                spent_coins: vec![TxOutId::new(TxId(2), 0)],
-                n_locktime: 0,
-            }
+                vec![TxOutId::new(TxId(2), 0)],
+                0,
+            )
         }
     }
 
@@ -101,25 +93,17 @@ pub(crate) mod tests {
     #[test]
     fn test_coinjoin_detection() {
         // Non-coinjoin tx
-        let normal_tx = DummyTxData {
-            outputs: vec![
-                DummyTxOutData::new_with_amount(100, 0),
-                DummyTxOutData::new_with_amount(200, 1),
-            ],
-            spent_coins: vec![],
-            n_locktime: 0,
-        };
+        let normal_tx = DummyTxData::new_with_outputs(vec![
+            DummyTxOutData::new_with_amount(100, 0),
+            DummyTxOutData::new_with_amount(200, 1),
+        ]);
 
         // Coinjoin tx (3+ outputs with same value)
-        let coinjoin_tx = DummyTxData {
-            outputs: vec![
-                DummyTxOutData::new_with_amount(100, 0),
-                DummyTxOutData::new_with_amount(100, 1),
-                DummyTxOutData::new_with_amount(100, 2),
-            ],
-            spent_coins: vec![],
-            n_locktime: 0,
-        };
+        let coinjoin_tx = DummyTxData::new_with_outputs(vec![
+            DummyTxOutData::new_with_amount(100, 0),
+            DummyTxOutData::new_with_amount(100, 1),
+            DummyTxOutData::new_with_amount(100, 2),
+        ]);
 
         let all_txs: Vec<Arc<dyn AbstractTransaction + Send + Sync>> =
             vec![Arc::new(normal_tx), Arc::new(coinjoin_tx)];
@@ -153,8 +137,8 @@ pub(crate) mod tests {
         let result = engine.eval(&mih_clustering);
 
         // The two inputs of spending_tx should be in the same cluster
-        let input1 = AnyOutId::from(TestFixture::spending_tx().spent_coins[0]);
-        let input2 = AnyOutId::from(TestFixture::spending_tx().spent_coins[1]);
+        let input1 = AnyOutId::from(TestFixture::spending_tx().spent_coins()[0]);
+        let input2 = AnyOutId::from(TestFixture::spending_tx().spent_coins()[1]);
         assert_eq!(result.find(input1), result.find(input2));
     }
 
@@ -175,8 +159,8 @@ pub(crate) mod tests {
 
         let result = engine.eval(&mih_clustering);
 
-        let input1 = AnyOutId::from(TestFixture::spending_tx().spent_coins[0]);
-        let input2 = AnyOutId::from(TestFixture::spending_tx().spent_coins[1]);
+        let input1 = AnyOutId::from(TestFixture::spending_tx().spent_coins()[0]);
+        let input2 = AnyOutId::from(TestFixture::spending_tx().spent_coins()[1]);
         assert_eq!(result.find(input1), result.find(input2));
     }
 
@@ -269,8 +253,8 @@ pub(crate) mod tests {
         let result = engine.eval(&combined);
 
         let change_output = AnyOutId::from(TestFixture::change_output());
-        let input0 = AnyOutId::from(TestFixture::spending_tx().spent_coins[0]);
-        let input1 = AnyOutId::from(TestFixture::spending_tx().spent_coins[1]);
+        let input0 = AnyOutId::from(TestFixture::spending_tx().spent_coins()[0]);
+        let input1 = AnyOutId::from(TestFixture::spending_tx().spent_coins()[1]);
 
         assert_eq!(result.find(change_output), result.find(input0));
         assert_eq!(result.find(change_output), result.find(input1));
@@ -282,38 +266,30 @@ pub(crate) mod tests {
 
         let txs = vec![
             // Coinbase 0
-            DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(1000, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            },
+            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(1000, 0)]),
             // tx1: spends coinbase 0, produces payment + change
-            DummyTxData {
-                outputs: vec![
+            DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(700, 0), // payment
                     DummyTxOutData::new_with_amount(300, 1), // change
                 ],
-                spent_coins: vec![TxOutId::new(TxId(1), 0)],
-                n_locktime: 0,
-            },
+                vec![TxOutId::new(TxId(1), 0)],
+                0,
+            ),
             // coinbase 2
-            DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(500, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            },
+            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(500, 0)]),
             // tx3: spends tx1 change + coinbase2
-            DummyTxData {
-                outputs: vec![
+            DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(400, 0), // payment
                     DummyTxOutData::new_with_amount(100, 1), // change
                 ],
-                spent_coins: vec![
+                vec![
                     TxOutId::new(TxId(2), 1), // spends tx1 change
                     TxOutId::new(TxId(3), 0), // spends coinbase2
                 ],
-                n_locktime: 0,
-            },
+                0,
+            ),
         ];
 
         let mut builder = LooseIndexBuilder::new();
@@ -348,29 +324,17 @@ pub(crate) mod tests {
         let ctx = Arc::new(PipelineContext::new());
 
         let txs = vec![
-            DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(1000, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            },
-            DummyTxData {
-                outputs: vec![
+            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(1000, 0)]),
+            DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(700, 0), // payment
                     DummyTxOutData::new_with_amount(300, 1), // change
                 ],
-                spent_coins: vec![TxOutId::new(TxId(1), 0)],
-                n_locktime: 0,
-            },
-            DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(300, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            },
-            DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(700, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            },
+                vec![TxOutId::new(TxId(1), 0)],
+                0,
+            ),
+            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(300, 0)]),
+            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(700, 0)]),
         ];
 
         let mut builder = LooseIndexBuilder::new();

--- a/src/crates/heuristics/src/ast/uih.rs
+++ b/src/crates/heuristics/src/ast/uih.rs
@@ -172,157 +172,129 @@ mod tests {
 
     fn setup_uih1_qualifying_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(200, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(100, 0),
+            ])),
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(200, 0),
+            ])),
+            Arc::new(DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(50, 0),
                     DummyTxOutData::new_with_amount(250, 1),
                 ],
-                spent_coins: vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                n_locktime: 0,
-            }),
+                vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+                0,
+            )),
         ]
     }
 
     fn setup_uih1_no_candidate_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(50, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(50, 0),
+            ])),
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(100, 0),
+            ])),
+            Arc::new(DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(80, 0),
                     DummyTxOutData::new_with_amount(70, 1),
                 ],
-                spent_coins: vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                n_locktime: 0,
-            }),
+                vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+                0,
+            )),
         ]
     }
 
     fn setup_uih1_tie_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(200, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(100, 0),
+            ])),
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(200, 0),
+            ])),
+            Arc::new(DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(50, 0),
                     DummyTxOutData::new_with_amount(50, 1),
                 ],
-                spent_coins: vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                n_locktime: 0,
-            }),
+                vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+                0,
+            )),
         ]
     }
 
     fn setup_uih2_no_unnecessary_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(200, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(100, 0),
+            ])),
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(200, 0),
+            ])),
+            Arc::new(DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(250, 0),
                     DummyTxOutData::new_with_amount(40, 1),
                 ],
-                spent_coins: vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                n_locktime: 0,
-            }),
+                vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+                0,
+            )),
         ]
     }
 
     fn setup_uih2_boundary_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(200, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(100, 0),
+            ])),
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(200, 0),
+            ])),
+            Arc::new(DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(200, 0),
                     DummyTxOutData::new_with_amount(0, 1),
                 ],
-                spent_coins: vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                n_locktime: 0,
-            }),
+                vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+                0,
+            )),
         ]
     }
 
     fn setup_uih_mixed_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(200, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(50, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(260, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(100, 0),
+            ])),
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(200, 0),
+            ])),
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(50, 0),
+            ])),
+            Arc::new(DummyTxData::new_with_outputs(vec![
+                DummyTxOutData::new_with_amount(260, 0),
+            ])),
+            Arc::new(DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(200, 0),
                     DummyTxOutData::new_with_amount(30, 1),
                 ],
-                spent_coins: vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                n_locktime: 0,
-            }),
-            Arc::new(DummyTxData {
-                outputs: vec![
+                vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+                0,
+            )),
+            Arc::new(DummyTxData::new(
+                vec![
                     DummyTxOutData::new_with_amount(270, 0),
                     DummyTxOutData::new_with_amount(10, 1),
                 ],
-                spent_coins: vec![TxOutId::new(TxId(3), 0), TxOutId::new(TxId(4), 0)],
-                n_locktime: 0,
-            }),
+                vec![TxOutId::new(TxId(3), 0), TxOutId::new(TxId(4), 0)],
+                0,
+            )),
         ]
     }
 

--- a/src/crates/heuristics/src/change_identification.rs
+++ b/src/crates/heuristics/src/change_identification.rs
@@ -52,11 +52,9 @@ mod tests {
     fn test_classify_change() {
         let txout = DummyTxOut {
             vout: 0,
-            containing_tx: DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            },
+            containing_tx: DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(
+                100, 0,
+            )]),
         };
         assert_eq!(
             NaiveChangeIdentificationHueristic::is_change(txout),
@@ -68,17 +66,12 @@ mod tests {
     fn test_n_locktime_change_identification() {
         let tx_out = DummyTxOut {
             vout: 0,
-            containing_tx: DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-                spent_coins: vec![],
-                n_locktime: 0,
-            },
+            containing_tx: DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(
+                100, 0,
+            )]),
         };
-        let spending_tx = DummyTxData {
-            outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-            spent_coins: vec![],
-            n_locktime: 0,
-        };
+        let spending_tx =
+            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(100, 0)]);
         assert_eq!(
             NLockTimeChangeIdentification::is_change(tx_out, spending_tx),
             TxOutChangeAnnotation::NotChange
@@ -87,17 +80,14 @@ mod tests {
         // Same lock time
         let tx_out = DummyTxOut {
             vout: 0,
-            containing_tx: DummyTxData {
-                outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-                spent_coins: vec![],
-                n_locktime: 1,
-            },
+            containing_tx: DummyTxData::new(
+                vec![DummyTxOutData::new_with_amount(100, 0)],
+                vec![],
+                1,
+            ),
         };
-        let spending_tx = DummyTxData {
-            outputs: vec![DummyTxOutData::new_with_amount(100, 0)],
-            spent_coins: vec![],
-            n_locktime: 1,
-        };
+        let spending_tx =
+            DummyTxData::new(vec![DummyTxOutData::new_with_amount(100, 0)], vec![], 1);
         assert_eq!(
             NLockTimeChangeIdentification::is_change(tx_out, spending_tx),
             TxOutChangeAnnotation::Change

--- a/src/crates/heuristics/src/coinjoin_detection.rs
+++ b/src/crates/heuristics/src/coinjoin_detection.rs
@@ -35,32 +35,24 @@ mod tests {
 
     #[test]
     fn test_is_coinjoin_tx() {
-        let not_coinjoin = DummyTxData {
-            outputs: vec![
-                DummyTxOutData::new_with_amount(100, 0),
-                DummyTxOutData::new_with_amount(200, 1),
-                DummyTxOutData::new_with_amount(300, 2),
-            ],
-            spent_coins: vec![],
-            n_locktime: 0,
-        };
+        let not_coinjoin = DummyTxData::new_with_outputs(vec![
+            DummyTxOutData::new_with_amount(100, 0),
+            DummyTxOutData::new_with_amount(200, 1),
+            DummyTxOutData::new_with_amount(300, 2),
+        ]);
         assert!(!NaiveCoinjoinDetection::is_coinjoin(&not_coinjoin));
 
-        let coinjoin = DummyTxData {
-            outputs: vec![
-                DummyTxOutData::new_with_amount(100, 0),
-                DummyTxOutData::new_with_amount(100, 1),
-                DummyTxOutData::new_with_amount(100, 2),
-                DummyTxOutData::new_with_amount(200, 3),
-                DummyTxOutData::new_with_amount(200, 4),
-                DummyTxOutData::new_with_amount(200, 5),
-                DummyTxOutData::new_with_amount(300, 6),
-                DummyTxOutData::new_with_amount(300, 7),
-                DummyTxOutData::new_with_amount(300, 8),
-            ],
-            spent_coins: vec![],
-            n_locktime: 0,
-        };
+        let coinjoin = DummyTxData::new_with_outputs(vec![
+            DummyTxOutData::new_with_amount(100, 0),
+            DummyTxOutData::new_with_amount(100, 1),
+            DummyTxOutData::new_with_amount(100, 2),
+            DummyTxOutData::new_with_amount(200, 3),
+            DummyTxOutData::new_with_amount(200, 4),
+            DummyTxOutData::new_with_amount(200, 5),
+            DummyTxOutData::new_with_amount(300, 6),
+            DummyTxOutData::new_with_amount(300, 7),
+            DummyTxOutData::new_with_amount(300, 8),
+        ]);
         assert!(NaiveCoinjoinDetection::is_coinjoin(&coinjoin));
     }
 }

--- a/src/crates/heuristics/src/common_input.rs
+++ b/src/crates/heuristics/src/common_input.rs
@@ -30,18 +30,18 @@ mod tests {
 
     #[test]
     fn test_multi_input_heuristic_merge_prevouts() {
-        let tx = DummyTxData {
-            outputs: vec![
+        let tx = DummyTxData::new(
+            vec![
                 DummyTxOutData::new_with_amount(500, 0),
                 DummyTxOutData::new_with_amount(300, 1),
             ],
-            spent_coins: vec![
+            vec![
                 TxOutId::new(TxId(2), 0),
                 TxOutId::new(TxId(3), 1),
                 TxOutId::new(TxId(4), 0),
             ],
-            n_locktime: 0,
-        };
+            0,
+        );
 
         let cluster = MultiInputHeuristic::merge_prevouts(&tx);
 

--- a/src/crates/primitives/src/test_utils/mod.rs
+++ b/src/crates/primitives/src/test_utils/mod.rs
@@ -14,10 +14,10 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DummyTxData {
-    pub outputs: Vec<DummyTxOutData>,
+    outputs: Vec<DummyTxOutData>,
     /// The outputs that are spent by this transaction
-    pub spent_coins: Vec<TxOutId>,
-    pub n_locktime: u32,
+    spent_coins: Vec<TxOutId>,
+    n_locktime: u32,
 }
 
 impl DummyTxData {
@@ -27,6 +27,18 @@ impl DummyTxData {
             spent_coins,
             n_locktime,
         }
+    }
+
+    pub fn new_with_outputs(outputs: Vec<DummyTxOutData>) -> Self {
+        Self {
+            outputs,
+            spent_coins: vec![],
+            n_locktime: 0,
+        }
+    }
+
+    pub fn spent_coins(&self) -> &[TxOutId] {
+        &self.spent_coins
     }
 }
 


### PR DESCRIPTION
make `DummyTxData` fields private and add constructors, matching `DummyTxOutData` pattern

part of #5 