### PR TITLE
Rename DummyTxOutData::new_with_amount to new

### DIFF
--- a/src/crates/heuristics/src/ast/tests.rs
+++ b/src/crates/heuristics/src/ast/tests.rs
@@ -23,27 +23,18 @@ pub(crate) mod tests {
 
     impl TestFixture {
         pub fn spending_tx() -> DummyTxData {
-            DummyTxData::new(
-                vec![
-                    // Payment output
-                    DummyTxOutData::new_with_amount(100, 0),
-                    // Change output
-                    DummyTxOutData::new_with_amount(150, 1),
-                ],
+            DummyTxData::new_with_spent(
+                vec![100, 150],
                 vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                0,
             )
         }
 
         pub fn coinbase1() -> DummyTxData {
-            DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(100, 0),
-                DummyTxOutData::new_with_amount(150, 1),
-            ])
+            DummyTxData::new_with_amounts(vec![100, 150])
         }
 
         pub fn coinbase2() -> DummyTxData {
-            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(150, 0)])
+            DummyTxData::new_with_amounts(vec![150])
         }
 
         pub fn payment_output() -> TxOutId {
@@ -56,14 +47,7 @@ pub(crate) mod tests {
 
         /// Single-input spending tx (spends coinbase2). Used for UIH2 single-input tests.
         pub fn single_input_spending_tx() -> DummyTxData {
-            DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(200, 0),
-                    DummyTxOutData::new_with_amount(300, 1),
-                ],
-                vec![TxOutId::new(TxId(2), 0)],
-                0,
-            )
+            DummyTxData::new_with_spent(vec![200, 300], vec![TxOutId::new(TxId(2), 0)])
         }
     }
 
@@ -90,17 +74,10 @@ pub(crate) mod tests {
     #[test]
     fn test_coinjoin_detection() {
         // Non-coinjoin tx
-        let normal_tx = DummyTxData::new_with_outputs(vec![
-            DummyTxOutData::new_with_amount(100, 0),
-            DummyTxOutData::new_with_amount(200, 1),
-        ]);
+        let normal_tx = DummyTxData::new_with_amounts(vec![100, 200]);
 
         // Coinjoin tx (3+ outputs with same value)
-        let coinjoin_tx = DummyTxData::new_with_outputs(vec![
-            DummyTxOutData::new_with_amount(100, 0),
-            DummyTxOutData::new_with_amount(100, 1),
-            DummyTxOutData::new_with_amount(100, 2),
-        ]);
+        let coinjoin_tx = DummyTxData::new_with_amounts(vec![100, 100, 100]);
 
         let all_txs: Vec<Arc<dyn AbstractTransaction + Send + Sync>> =
             vec![Arc::new(normal_tx), Arc::new(coinjoin_tx)];
@@ -263,29 +240,18 @@ pub(crate) mod tests {
 
         let txs = vec![
             // Coinbase 0
-            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(1000, 0)]),
+            DummyTxData::new_with_amounts(vec![1000]),
             // tx1: spends coinbase 0, produces payment + change
-            DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(700, 0), // payment
-                    DummyTxOutData::new_with_amount(300, 1), // change
-                ],
-                vec![TxOutId::new(TxId(1), 0)],
-                0,
-            ),
+            DummyTxData::new_with_spent(vec![700, 300], vec![TxOutId::new(TxId(1), 0)]),
             // coinbase 2
-            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(500, 0)]),
+            DummyTxData::new_with_amounts(vec![500]),
             // tx3: spends tx1 change + coinbase2
-            DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(400, 0), // payment
-                    DummyTxOutData::new_with_amount(100, 1), // change
-                ],
+            DummyTxData::new_with_spent(
+                vec![400, 100],
                 vec![
                     TxOutId::new(TxId(2), 1), // spends tx1 change
                     TxOutId::new(TxId(3), 0), // spends coinbase2
                 ],
-                0,
             ),
         ];
 
@@ -318,17 +284,17 @@ pub(crate) mod tests {
         let ctx = Arc::new(PipelineContext::new());
 
         let txs = vec![
-            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(1000, 0)]),
+            DummyTxData::new_with_amounts(vec![1000]),
             DummyTxData::new(
                 vec![
-                    DummyTxOutData::new_with_amount(700, 0), // payment
-                    DummyTxOutData::new_with_amount(300, 1), // change
+                    DummyTxOutData::new(700, 0), // payment
+                    DummyTxOutData::new(300, 1), // change
                 ],
                 vec![TxOutId::new(TxId(1), 0)],
                 0,
             ),
-            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(300, 0)]),
-            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(700, 0)]),
+            DummyTxData::new_with_amounts(vec![300]),
+            DummyTxData::new_with_amounts(vec![700]),
         ];
 
         let mut builder = LooseIndexBuilder::new();

--- a/src/crates/heuristics/src/ast/uih.rs
+++ b/src/crates/heuristics/src/ast/uih.rs
@@ -169,128 +169,72 @@ mod tests {
 
     fn setup_uih1_qualifying_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(100, 0),
-            ])),
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(200, 0),
-            ])),
-            Arc::new(DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(50, 0),
-                    DummyTxOutData::new_with_amount(250, 1),
-                ],
+            Arc::new(DummyTxData::new_with_amounts(vec![100])),
+            Arc::new(DummyTxData::new_with_amounts(vec![200])),
+            Arc::new(DummyTxData::new_with_spent(
+                vec![50, 250],
                 vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                0,
             )),
         ]
     }
 
     fn setup_uih1_no_candidate_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(50, 0),
-            ])),
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(100, 0),
-            ])),
-            Arc::new(DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(80, 0),
-                    DummyTxOutData::new_with_amount(70, 1),
-                ],
+            Arc::new(DummyTxData::new_with_amounts(vec![50])),
+            Arc::new(DummyTxData::new_with_amounts(vec![100])),
+            Arc::new(DummyTxData::new_with_spent(
+                vec![80, 70],
                 vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                0,
             )),
         ]
     }
 
     fn setup_uih1_tie_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(100, 0),
-            ])),
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(200, 0),
-            ])),
-            Arc::new(DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(50, 0),
-                    DummyTxOutData::new_with_amount(50, 1),
-                ],
+            Arc::new(DummyTxData::new_with_amounts(vec![100])),
+            Arc::new(DummyTxData::new_with_amounts(vec![200])),
+            Arc::new(DummyTxData::new_with_spent(
+                vec![50, 50],
                 vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                0,
             )),
         ]
     }
 
     fn setup_uih2_no_unnecessary_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(100, 0),
-            ])),
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(200, 0),
-            ])),
-            Arc::new(DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(250, 0),
-                    DummyTxOutData::new_with_amount(40, 1),
-                ],
+            Arc::new(DummyTxData::new_with_amounts(vec![100])),
+            Arc::new(DummyTxData::new_with_amounts(vec![200])),
+            Arc::new(DummyTxData::new_with_spent(
+                vec![250, 40],
                 vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                0,
             )),
         ]
     }
 
     fn setup_uih2_boundary_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(100, 0),
-            ])),
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(200, 0),
-            ])),
-            Arc::new(DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(200, 0),
-                    DummyTxOutData::new_with_amount(0, 1),
-                ],
+            Arc::new(DummyTxData::new_with_amounts(vec![100])),
+            Arc::new(DummyTxData::new_with_amounts(vec![200])),
+            Arc::new(DummyTxData::new_with_spent(
+                vec![200, 0],
                 vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                0,
             )),
         ]
     }
 
     fn setup_uih_mixed_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>> {
         vec![
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(100, 0),
-            ])),
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(200, 0),
-            ])),
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(50, 0),
-            ])),
-            Arc::new(DummyTxData::new_with_outputs(vec![
-                DummyTxOutData::new_with_amount(260, 0),
-            ])),
-            Arc::new(DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(200, 0),
-                    DummyTxOutData::new_with_amount(30, 1),
-                ],
+            Arc::new(DummyTxData::new_with_amounts(vec![100])),
+            Arc::new(DummyTxData::new_with_amounts(vec![200])),
+            Arc::new(DummyTxData::new_with_amounts(vec![50])),
+            Arc::new(DummyTxData::new_with_amounts(vec![260])),
+            Arc::new(DummyTxData::new_with_spent(
+                vec![200, 30],
                 vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
-                0,
             )),
-            Arc::new(DummyTxData::new(
-                vec![
-                    DummyTxOutData::new_with_amount(270, 0),
-                    DummyTxOutData::new_with_amount(10, 1),
-                ],
+            Arc::new(DummyTxData::new_with_spent(
+                vec![270, 10],
                 vec![TxOutId::new(TxId(3), 0), TxOutId::new(TxId(4), 0)],
-                0,
             )),
         ]
     }

--- a/src/crates/heuristics/src/change_identification.rs
+++ b/src/crates/heuristics/src/change_identification.rs
@@ -52,9 +52,7 @@ mod tests {
     fn test_classify_change() {
         let txout = DummyTxOut {
             vout: 0,
-            containing_tx: DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(
-                100, 0,
-            )]),
+            containing_tx: DummyTxData::new_with_amounts(vec![100]),
         };
         assert_eq!(
             NaiveChangeIdentificationHueristic::is_change(txout),
@@ -66,12 +64,9 @@ mod tests {
     fn test_n_locktime_change_identification() {
         let tx_out = DummyTxOut {
             vout: 0,
-            containing_tx: DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(
-                100, 0,
-            )]),
+            containing_tx: DummyTxData::new_with_amounts(vec![100]),
         };
-        let spending_tx =
-            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_amount(100, 0)]);
+        let spending_tx = DummyTxData::new_with_amounts(vec![100]);
         assert_eq!(
             NLockTimeChangeIdentification::is_change(tx_out, spending_tx),
             TxOutChangeAnnotation::NotChange
@@ -80,14 +75,9 @@ mod tests {
         // Same lock time
         let tx_out = DummyTxOut {
             vout: 0,
-            containing_tx: DummyTxData::new(
-                vec![DummyTxOutData::new_with_amount(100, 0)],
-                vec![],
-                1,
-            ),
+            containing_tx: DummyTxData::new(vec![DummyTxOutData::new(100, 0)], vec![], 1),
         };
-        let spending_tx =
-            DummyTxData::new(vec![DummyTxOutData::new_with_amount(100, 0)], vec![], 1);
+        let spending_tx = DummyTxData::new(vec![DummyTxOutData::new(100, 0)], vec![], 1);
         assert_eq!(
             NLockTimeChangeIdentification::is_change(tx_out, spending_tx),
             TxOutChangeAnnotation::Change

--- a/src/crates/heuristics/src/coinjoin_detection.rs
+++ b/src/crates/heuristics/src/coinjoin_detection.rs
@@ -29,30 +29,17 @@ impl NaiveCoinjoinDetection {
 #[cfg(test)]
 mod tests {
 
-    use tx_indexer_primitives::test_utils::{DummyTxData, DummyTxOutData};
+    use tx_indexer_primitives::test_utils::DummyTxData;
 
     use super::*;
 
     #[test]
     fn test_is_coinjoin_tx() {
-        let not_coinjoin = DummyTxData::new_with_outputs(vec![
-            DummyTxOutData::new_with_amount(100, 0),
-            DummyTxOutData::new_with_amount(200, 1),
-            DummyTxOutData::new_with_amount(300, 2),
-        ]);
+        let not_coinjoin = DummyTxData::new_with_amounts(vec![100, 200, 300]);
         assert!(!NaiveCoinjoinDetection::is_coinjoin(&not_coinjoin));
 
-        let coinjoin = DummyTxData::new_with_outputs(vec![
-            DummyTxOutData::new_with_amount(100, 0),
-            DummyTxOutData::new_with_amount(100, 1),
-            DummyTxOutData::new_with_amount(100, 2),
-            DummyTxOutData::new_with_amount(200, 3),
-            DummyTxOutData::new_with_amount(200, 4),
-            DummyTxOutData::new_with_amount(200, 5),
-            DummyTxOutData::new_with_amount(300, 6),
-            DummyTxOutData::new_with_amount(300, 7),
-            DummyTxOutData::new_with_amount(300, 8),
-        ]);
+        let coinjoin =
+            DummyTxData::new_with_amounts(vec![100, 100, 100, 200, 200, 200, 300, 300, 300]);
         assert!(NaiveCoinjoinDetection::is_coinjoin(&coinjoin));
     }
 }

--- a/src/crates/heuristics/src/common_input.rs
+++ b/src/crates/heuristics/src/common_input.rs
@@ -30,17 +30,13 @@ mod tests {
 
     #[test]
     fn test_multi_input_heuristic_merge_prevouts() {
-        let tx = DummyTxData::new(
-            vec![
-                DummyTxOutData::new_with_amount(500, 0),
-                DummyTxOutData::new_with_amount(300, 1),
-            ],
+        let tx = DummyTxData::new_with_spent(
+            vec![500, 300],
             vec![
                 TxOutId::new(TxId(2), 0),
                 TxOutId::new(TxId(3), 1),
                 TxOutId::new(TxId(4), 0),
             ],
-            0,
         );
 
         let cluster = MultiInputHeuristic::merge_prevouts(&tx);

--- a/src/crates/primitives/src/test_utils/mod.rs
+++ b/src/crates/primitives/src/test_utils/mod.rs
@@ -21,6 +21,7 @@ pub struct DummyTxData {
 }
 
 impl DummyTxData {
+    /// Base constructor.
     pub fn new(outputs: Vec<DummyTxOutData>, spent_coins: Vec<TxOutId>, n_locktime: u32) -> Self {
         Self {
             outputs,
@@ -28,13 +29,29 @@ impl DummyTxData {
             n_locktime,
         }
     }
-
+    /// Tx with explicit outputs, no spent coins.
     pub fn new_with_outputs(outputs: Vec<DummyTxOutData>) -> Self {
         Self {
             outputs,
             spent_coins: vec![],
             n_locktime: 0,
         }
+    }
+
+    /// Create funding tx from amounts.
+    pub fn new_with_amounts(amounts: Vec<u64>) -> Self {
+        let outputs = amounts
+            .into_iter()
+            .enumerate()
+            .map(|(vout, amount)| DummyTxOutData::new(amount, vout as u32))
+            .collect();
+        Self::new_with_outputs(outputs)
+    }
+
+    /// Create spending tx from amounts and spent coins.
+    pub fn new_with_spent(amounts: Vec<u64>, spent_coins: Vec<TxOutId>) -> Self {
+        let base = Self::new_with_amounts(amounts);
+        Self::new(base.outputs, spent_coins, 0)
     }
 
     pub fn spent_coins(&self) -> &[TxOutId] {
@@ -76,16 +93,8 @@ pub struct DummyTxOutData {
 }
 
 impl DummyTxOutData {
-    pub fn new(value: u64, vout: u32) -> Self {
-        Self {
-            value,
-            vout,
-            script_pubkey: vec![],
-        }
-    }
-
-    /// Create a new DummyTxOutData with a given amount and a dummy script pubkey
-    pub fn new_with_amount(amount: u64, vout: u32) -> Self {
+    /// Create a new output with empty script pubkey.
+    pub fn new(amount: u64, vout: u32) -> Self {
         Self {
             value: amount,
             vout,
@@ -93,7 +102,7 @@ impl DummyTxOutData {
         }
     }
 
-    /// Create a new DummyTxOutData with explicit script pubkey bytes
+    /// Create a new output with explicit script pubkey.
     pub fn new_with_script(amount: u64, vout: u32, script_pubkey: impl Into<Vec<u8>>) -> Self {
         Self {
             value: amount,


### PR DESCRIPTION
rename  `DummyTxOutData::new_with_amount` to `new` for the most common constructor and align with `DummyTxData`