### PR TITLE
Expose Block Height to TxHandle

### DIFF
--- a/src/crates/primitives/src/dense/mod.rs
+++ b/src/crates/primitives/src/dense/mod.rs
@@ -73,6 +73,7 @@ pub struct IndexPaths {
 
 pub struct DenseStorage {
     blocks_dir: PathBuf,
+    block_height_offset: u64,
     txptr_index: ConfirmedTxPtrIndex,
     block_tx_index: BlockTxIndex,
     in_prevout_index: InPrevoutIndex,
@@ -86,6 +87,7 @@ pub fn build_indices(
     paths: IndexPaths,
     mut spk_db: SledScriptPubkeyDb,
 ) -> Result<DenseStorage, BlockFileError> {
+    let block_height_offset = range.start;
     let mut parser = Parser::new(blocks_dir);
     let mut txptr_index = ConfirmedTxPtrIndex::create(&paths.txptr).map_err(BlockFileError::Io)?;
     let mut block_tx_index = BlockTxIndex::create(&paths.block_tx).map_err(BlockFileError::Io)?;
@@ -103,6 +105,7 @@ pub fn build_indices(
     )?;
     let storage = DenseStorage {
         blocks_dir: parser.blocks_dir().to_path_buf(),
+        block_height_offset,
         txptr_index,
         block_tx_index,
         in_prevout_index,
@@ -202,12 +205,13 @@ impl DenseStorage {
                 .unwrap_or_else(|| panic!("Corrupted data store: block height out of range: {}", i))
                 as u64
         };
-        Self::upper_bound(len, target, value_at).unwrap_or_else(|| {
+        let relative = Self::upper_bound(len, target, value_at).unwrap_or_else(|| {
             panic!(
                 "Corrupted data store: txid out of range for block index: {}",
                 target
             )
-        })
+        });
+        relative + self.block_height_offset
     }
 
     /// Return the range of TxInIds for the given transaction.

--- a/src/crates/primitives/src/handle.rs
+++ b/src/crates/primitives/src/handle.rs
@@ -53,6 +53,10 @@ impl<'a> TxHandle<'a> {
                 index: self.index,
             })
     }
+
+    pub fn block_height(&self) -> Option<u64> {
+        self.index.block_height(&self.tx_id)
+    }
 }
 
 /// Handle for a transaction output in a unified index.

--- a/src/crates/primitives/src/loose/mod.rs
+++ b/src/crates/primitives/src/loose/mod.rs
@@ -296,6 +296,10 @@ impl TxIoIndex for InMemoryIndex {
     fn script_sig_bytes(&self, _in_id: &AnyInId) -> Vec<u8> {
         todo!()
     }
+
+    fn block_height(&self, _txid: &AnyTxId) -> Option<u64> {
+        None
+    }
 }
 
 impl OutpointIndex for InMemoryIndex {

--- a/src/crates/primitives/src/traits/graph_index.rs
+++ b/src/crates/primitives/src/traits/graph_index.rs
@@ -35,6 +35,7 @@ pub trait TxIoIndex {
     fn input_sequence(&self, in_id: &AnyInId) -> u32;
     fn witness_items(&self, in_id: &AnyInId) -> Vec<Vec<u8>>;
     fn script_sig_bytes(&self, in_id: &AnyInId) -> Vec<u8>;
+    fn block_height(&self, txid: &AnyTxId) -> Option<u64>;
 }
 
 pub trait OutpointIndex {

--- a/src/crates/primitives/src/unified/mod.rs
+++ b/src/crates/primitives/src/unified/mod.rs
@@ -512,6 +512,11 @@ impl TxIoIndex for UnifiedStorage {
         let vin = (did.index() - start) as usize;
         ds.get_tx(txid).input[vin].script_sig.to_bytes()
     }
+
+    fn block_height(&self, txid: &AnyTxId) -> Option<u64> {
+        txid.confirmed_txid()
+            .map(|did| self.dense().block_of_tx(did))
+    }
 }
 
 impl OutpointIndex for UnifiedStorage {


### PR DESCRIPTION
adds `block_height` to `TxHandle` via `TxIoIndex`, allowing heuristics to query the confirmed block height of a transaction.

`block_of_tx` now returns the absolute chain height instead of a range-relative index, by storing `range.start` as an offset in `DenseStorage` at index time

part of #5 