### PR TITLE
Audit storage panics: push panic decisions to callers

### DIFF
--- a/src/crates/primitives/src/loose/mod.rs
+++ b/src/crates/primitives/src/loose/mod.rs
@@ -164,10 +164,10 @@ impl InMemoryIndex {
             let prev_vout = txin.prev_vout();
             let prev_txid = txin.prev_txid();
             if let (Some(prev_vout), Some(prev_txid)) = (prev_vout, prev_txid) {
-                let prev_outid = TxOutId::new(
-                    prev_txid.loose_txid().expect("prev_txid should be loose"),
-                    prev_vout,
-                );
+                let Some(prev_loose_txid) = prev_txid.loose_txid() else {
+                    todo!("link loose tx input to confirmed (dense) prevout");
+                };
+                let prev_outid = TxOutId::new(prev_loose_txid, prev_vout);
                 self.spending_txins.insert(prev_outid, vin_id);
                 self.prev_txouts.insert(vin_id, prev_outid);
             }

--- a/src/crates/primitives/src/traits/graph_index.rs
+++ b/src/crates/primitives/src/traits/graph_index.rs
@@ -35,6 +35,7 @@ pub trait TxIoIndex {
     fn input_sequence(&self, in_id: &AnyInId) -> u32;
     fn witness_items(&self, in_id: &AnyInId) -> Vec<Vec<u8>>;
     fn script_sig_bytes(&self, in_id: &AnyInId) -> Vec<u8>;
+    // block_height is optional because loose transactions are not confirmed.
     fn block_height(&self, txid: &AnyTxId) -> Option<u64>;
 }
 
@@ -42,6 +43,8 @@ pub trait OutpointIndex {
     fn outpoint_for_out(&self, out_id: &AnyOutId) -> (AnyTxId, u32);
 }
 
+/// Concrete types because every indexed txout has these fields.
+/// A missing value means index corruption or an internal bug, not legitimately absent data.
 pub trait TxOutDataIndex {
     fn value(&self, out_id: &AnyOutId) -> Amount;
     fn script_pubkey_hash(&self, out_id: &AnyOutId) -> ScriptPubkeyHash;

--- a/src/crates/primitives/src/unified/mod.rs
+++ b/src/crates/primitives/src/unified/mod.rs
@@ -292,12 +292,11 @@ impl UnifiedStorage {
             .expect("loose txid not found in storage")
     }
 
+    // Returns empty Vec when loose storage is absent
     pub fn loose_txids(&self) -> Vec<AnyTxId> {
-        let loose = self
-            .loose
-            .as_ref()
-            .expect("loose storage missing when requesting loose txids");
-        loose.tx_order.iter().copied().map(AnyTxId::from).collect()
+        self.loose.as_ref().map_or(Vec::new(), |loose| {
+            loose.tx_order.iter().copied().map(AnyTxId::from).collect()
+        })
     }
 
     pub fn loose_txids_len(&self) -> usize {
@@ -311,18 +310,16 @@ impl UnifiedStorage {
     }
 
     pub fn loose_txids_from(&self, start: usize) -> Vec<AnyTxId> {
-        let loose = self
-            .loose
-            .as_ref()
-            .expect("loose storage missing when requesting loose txids");
-        if start >= loose.tx_order.len() {
-            return Vec::new();
-        }
-        loose.tx_order[start..]
-            .iter()
-            .copied()
-            .map(AnyTxId::from)
-            .collect()
+        self.loose.as_ref().map_or(Vec::new(), |loose| {
+            if start >= loose.tx_order.len() {
+                return Vec::new();
+            }
+            loose.tx_order[start..]
+                .iter()
+                .copied()
+                .map(AnyTxId::from)
+                .collect()
+        })
     }
 
     pub fn dense_txids_from(&self, start: usize) -> Vec<AnyTxId> {
@@ -381,12 +378,12 @@ impl UnifiedStorage {
         )
     }
 
-    pub fn tx(&self, txid: AnyTxId) -> std::sync::Arc<dyn AbstractTransaction> {
+    // TODO: support confirmed tx access
+    pub fn tx(&self, txid: AnyTxId) -> std::sync::Arc<dyn AbstractTransaction + Send + Sync> {
         if let Some(loose_txid) = txid.loose_txid() {
             return self.loose_tx(loose_txid).clone();
         }
-        // TODO: support confirmed tx access
-        panic!("confirmed tx access not supported yet");
+        todo!("confirmed tx access not supported yet")
     }
 
     pub fn script_pubkey_to_txout_id(&self, script_pubkey: &ScriptPubkeyHash) -> Option<AnyOutId> {


### PR DESCRIPTION
audit storage panics for partial indexing #32 compatibility. Fix panics that don't make sense with tip-to-depth indexing and improve error messages for the ones that stay.

closes #40 
part of #35 
part of #5 