### PR TITLE
Fix signet indexing 

### DIFF
--- a/src/crates/primitives/src/dense/mod.rs
+++ b/src/crates/primitives/src/dense/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         BlockTxIndex, ConfirmedTxPtrIndex, INID_NONE, InPrevoutIndex, OUTID_NONE, OutSpentByIndex,
         TxPtr,
     },
-    parser::{BlockFileError, Parser},
+    parser::{BlkFileHint, BlockFileError, Parser},
     sled::{db::SledDBFactory, spk_db::SledScriptPubkeyDb},
     traits::ScriptPubkeyDb,
     unified::SyncError,
@@ -75,7 +75,7 @@ pub struct DenseStorageBuilder {
     data_dir: PathBuf,
     index_dir: PathBuf,
     range: std::ops::Range<u64>,
-    file_hints: Vec<(u32, u32, u32)>,
+    file_hints: Vec<BlkFileHint>,
 }
 
 impl DenseStorageBuilder {
@@ -83,7 +83,7 @@ impl DenseStorageBuilder {
         data_dir: PathBuf,
         index_dir: PathBuf,
         range: std::ops::Range<u64>,
-        file_hints: Vec<(u32, u32, u32)>,
+        file_hints: Vec<BlkFileHint>,
     ) -> Self {
         Self {
             data_dir,
@@ -169,18 +169,18 @@ impl DenseStorageBuilder {
         Ok(builder)
     }
 
-    /// Collect `(file_no, height_first, height_last)` hints for every blk file that
+    /// Collect [`BlkFileHint`] entries for every blk file that
     /// overlaps the inclusive height range `[start_height, end_height]`, so the parser
     /// can skip blk files outside the requested range.
     fn collect_file_hints(
         index: &mut bitcoin_block_index::BlockIndex,
         start_height: u64,
         end_height: u64,
-    ) -> Result<Vec<(u32, u32, u32)>, BlockFileError> {
+    ) -> Result<Vec<BlkFileHint>, BlockFileError> {
         let last_file = index
             .last_block_file()
             .map_err(BlockFileError::BlockIndex)?;
-        let mut file_hints: Vec<(u32, u32, u32)> = Vec::new();
+        let mut file_hints: Vec<BlkFileHint> = Vec::new();
 
         for file_no in 0..=last_file {
             let info = index
@@ -194,7 +194,12 @@ impl DenseStorageBuilder {
             if (info.height_first as u64) > end_height {
                 break;
             }
-            file_hints.push((file_no, info.height_first, info.height_last));
+            file_hints.push(BlkFileHint {
+                file_no,
+                height_first: info.height_first,
+                height_last: info.height_last,
+                data_len: Some(info.size as usize),
+            });
         }
 
         Ok(file_hints)

--- a/src/crates/primitives/src/parser.rs
+++ b/src/crates/primitives/src/parser.rs
@@ -24,16 +24,40 @@ const BLOCK_START_LEN: usize = 8;
 
 // TODO: provide option to memory map the block files
 
+/// Parser-side blk file metadata used to locate and bound parsing within a file.
+///
+/// `file_no` selects the `blkNNNNN.dat` file, `height_first`/`height_last`
+/// describe the expected height range in that file, and `data_len` is the
+/// logical used byte length when known.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlkFileHint {
+    pub file_no: u32,
+    pub height_first: u32,
+    pub height_last: u32,
+    pub data_len: Option<usize>,
+}
+
+impl Default for BlkFileHint {
+    fn default() -> Self {
+        Self {
+            file_no: 0,
+            height_first: 0,
+            height_last: u32::MAX,
+            data_len: None,
+        }
+    }
+}
+
 /// Storage for dense IDs backed by Bitcoin Core block files.
 ///
 /// Parses blocks via bitcoin_slices (Visitor pattern).
 pub struct Parser {
     store: BlkFileStore,
-    /// Blk file layout: each entry is `(file_no, height_first, height_last)`.
+    /// Blk file layout hints for the files this parser should scan.
     ///
     /// If empty, all blocks are assumed to be in `blk00000.dat` starting at height 0
     /// (suitable for regtest or small test chains).
-    file_hints: Vec<(u32, u32, u32)>,
+    file_hints: Vec<BlkFileHint>,
 }
 
 impl Parser {
@@ -45,9 +69,7 @@ impl Parser {
     }
 
     /// Set blk file layout hints so the parser can locate blocks in multi-file chains.
-    ///
-    /// Each hint is `(file_no, height_first, height_last)`, sorted by `file_no`.
-    pub fn with_file_hints(mut self, hints: Vec<(u32, u32, u32)>) -> Self {
+    pub fn with_file_hints(mut self, hints: Vec<BlkFileHint>) -> Self {
         self.file_hints = hints;
         self
     }
@@ -75,8 +97,8 @@ impl Parser {
         spk_db: &mut SledScriptPubkeyDb,
     ) -> Result<(), BlockFileError> {
         // Default: single file starting at height 0.
-        let default_hint = [(0u32, 0u32, u32::MAX)];
-        let hints: &[(u32, u32, u32)] = if self.file_hints.is_empty() {
+        let default_hint = [BlkFileHint::default()];
+        let hints: &[BlkFileHint] = if self.file_hints.is_empty() {
             &default_hint
         } else {
             &self.file_hints
@@ -89,7 +111,9 @@ impl Parser {
             .unwrap_or(0) as u64;
         let mut txids = HashMap::new();
 
-        'files: for &(file_no, height_first, _height_last) in hints {
+        'files: for hint in hints {
+            let file_no = hint.file_no;
+            let height_first = hint.height_first;
             let file_first = height_first as u64;
             // Skip files entirely before range.
             if file_first > range.end.saturating_sub(1) {
@@ -98,6 +122,22 @@ impl Parser {
 
             let file_id = BlockFileId(file_no);
             let bytes = self.store.read_file(file_no).map_err(BlockFileError::Io)?;
+            let used_len = match hint.data_len {
+                Some(data_len) => {
+                    let used_len = data_len;
+                    if used_len > bytes.len() {
+                        return Err(BlockFileError::UnexpectedEof {
+                            offset: used_len,
+                            len: bytes.len(),
+                        });
+                    }
+                    used_len
+                }
+                None => bytes.len(),
+            };
+            // Only parse the logical bytes Bitcoin Core says are used. This avoids
+            // interpreting the preallocated tail of the active blk file as block data.
+            let bytes = &bytes[..used_len];
 
             let mut global_height = file_first;
             let mut offset = 0usize;

--- a/src/crates/primitives/src/tests.rs
+++ b/src/crates/primitives/src/tests.rs
@@ -3,11 +3,13 @@ mod primitive_tests {
     use anyhow::Result;
     use bitcoin::{Amount, hashes::Hash};
     use std::{
+        fs,
         path::PathBuf,
         sync::{Arc, Mutex},
     };
 
     use crate::integration::run_harness;
+    use crate::parser::BlkFileHint;
     use crate::test_utils::temp_dir;
     use crate::{
         UnifiedStorage,
@@ -56,6 +58,67 @@ mod primitive_tests {
 
         // TODO: parse from genesis to tip and repeat assertions
 
+        Ok(())
+    }
+
+    #[test]
+    fn build_indices_stops_at_logical_blk_size() -> Result<()> {
+        let fixture_blocks = fixture_dir().join("blocks");
+        let plaintext = fs::read(fixture_blocks.join("blk00000.dat"))?;
+        let logical_size = plaintext.len();
+
+        let mut xor_key = [0u8; 8];
+        let phase = logical_size % xor_key.len();
+        // Make the zero-padded tail look like a plausible block header after XOR
+        // decoding, so parsing past `data_len` would fail.
+        let fake_tail_header = [0x11, 0x22, 0x33, 0x44, 0xff, 0xff, 0xff, 0xff];
+        for (i, byte) in fake_tail_header.iter().enumerate() {
+            xor_key[(phase + i) % xor_key.len()] = *byte;
+        }
+
+        let mut encrypted = plaintext.clone();
+        for (i, byte) in encrypted.iter_mut().enumerate() {
+            *byte ^= xor_key[i % xor_key.len()];
+        }
+
+        let tx_count_for = |dir_prefix: &str, blk_bytes: &[u8]| -> Result<u64> {
+            let datadir = temp_dir(dir_prefix);
+            let blocks_dir = datadir.join("blocks");
+            fs::create_dir_all(&blocks_dir)?;
+            fs::write(blocks_dir.join("xor.dat"), xor_key)?;
+            fs::write(blocks_dir.join("blk00000.dat"), blk_bytes)?;
+
+            let storage = DenseStorageBuilder::new(
+                datadir,
+                temp_dir("preallocated_blk_index"),
+                0..100,
+                vec![BlkFileHint {
+                    file_no: 0,
+                    height_first: 0,
+                    height_last: u32::MAX,
+                    data_len: Some(logical_size),
+                }],
+            )
+            .build()?;
+
+            Ok(storage.tx_count())
+        };
+
+        let baseline_tx_count = tx_count_for("preallocated_blk_fixture_baseline", &encrypted)?;
+
+        let mut disk_bytes = encrypted.clone();
+        // Appending zeros simulates the preallocated tail of the active blk file.
+        disk_bytes.extend(std::iter::repeat_n(0u8, 4096));
+        let tailed_tx_count = tx_count_for("preallocated_blk_fixture_tailed", &disk_bytes)?;
+
+        assert!(
+            baseline_tx_count > 0,
+            "fixture should contribute at least one tx"
+        );
+        assert_eq!(
+            tailed_tx_count, baseline_tx_count,
+            "bytes past data_len must not change the parsed result"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
closes: #62 
This PR fixes blk file parsing by using Bitcoin Core’s recorded logical file size (BlockFileInfo.size) instead of the raw filesystem length. That prevents the parser from reading into the preallocated tail of the active blk*.dat file, which can look like garbage after XOR decoding and cause unexpected EOF errors.

Reasoning for this approach are here  https://github.com/payjoin/tx-indexer/issues/62#issuecomment-4290059480

Message for reviwers:
After this fix indexing is working with results below, but if a better approach is available would appreciate suggestions

```
tx-indexer on  data_length [$!?] is 📦 v0.1.0 via 🦀 v1.92.0-nightly 
❯ time cargo run --example indexer -- --datadir ~/.bitcoin/signet --depth 1000
   Compiling tx-indexer-primitives v0.1.0 (/home/shehu/Documents/os/tx-indexer/src/crates/primitives)
   Compiling tx-indexer-fingerprints v0.1.0 (/home/shehu/Documents/os/tx-indexer/src/crates/fingerprints)
   Compiling tx-indexer-pipeline v0.1.0 (/home/shehu/Documents/os/tx-indexer/src/crates/pipeline)
   Compiling tx-indexer-heuristics v0.1.0 (/home/shehu/Documents/os/tx-indexer/src/crates/heuristics)
   Compiling bitcoin-transaction-indexer v0.1.0 (/home/shehu/Documents/os/tx-indexer)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.84s
     Running `target/debug/examples/indexer --datadir /home/shehu/.bitcoin/signet --depth 1000`
Indexing last 1001 blocks (depth: 1000) from /home/shehu/.bitcoin/signet
Indexed 90835 transactions in 1001 blocks (27.46s)

--- RBF signaling analysis (5.49s) ---
Transactions signaling RBF: 58863/90835 (64.8%)
cargo run --example indexer -- --datadir ~/.bitcoin/signet --depth 1000  31.64s user 4.81s system 107% cpu 33.976 total

tx-indexer on  data_length [$!?] is 📦 v0.1.0 via 🦀 v1.92.0-nightly took 34s 
❯ time cargo run --example indexer -- --datadir ~/.bitcoin/signet --depth 100 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/examples/indexer --datadir /home/shehu/.bitcoin/signet --depth 100`
Indexing last 101 blocks (depth: 100) from /home/shehu/.bitcoin/signet
Indexed 13253 transactions in 101 blocks (7.11s)

--- RBF signaling analysis (860.65ms) ---
Transactions signaling RBF: 7659/13253 (57.8%)
cargo run --example indexer -- --datadir ~/.bitcoin/signet --depth 100  7.68s user 0.68s system 102% cpu 8.137 total
```