### PR TITLE
Exclude `OP_RETURN` outputs from change identification heuristics

### DIFF
--- a/src/crates/heuristics/src/ast/change.rs
+++ b/src/crates/heuristics/src/ast/change.rs
@@ -9,11 +9,12 @@ use tx_indexer_pipeline::{
 };
 use tx_indexer_primitives::{
     AbstractTxIn,
+    handle::SpendableTxConstituent,
     unified::{AnyOutId, AnyTxId},
 };
 
 use crate::change_identification::{
-    NLockTimeChangeIdentification, NaiveChangeIdentificationHueristic, TxOutChangeAnnotation,
+    NLockTimeChangeIdentification, NaiveChangeIdentificationHeuristic, TxOutChangeAnnotation,
 };
 
 /// Node that identifies change outputs in transactions.
@@ -44,10 +45,13 @@ impl Node for ChangeIdentificationNode {
 
         for output_id in txouts.iter() {
             let output = output_id.with(ctx.unified_storage());
-            let is_change = matches!(
-                NaiveChangeIdentificationHueristic::is_change(output),
-                TxOutChangeAnnotation::Change
-            );
+            let is_change = match SpendableTxConstituent::try_new(output) {
+                Ok(spendable) => matches!(
+                    NaiveChangeIdentificationHeuristic::is_change(spendable),
+                    TxOutChangeAnnotation::Change
+                ),
+                Err(_) => false, // OP_RETURN outputs cannot be change
+            };
             result.insert(*output_id, is_change);
         }
 
@@ -114,10 +118,13 @@ impl Node for FingerPrintChangeIdentificationNode {
             let is_change = match output.spender_txin() {
                 Some(spending_txin) => {
                     let spending_tx = spending_txin.containing_tx();
-                    matches!(
-                        NLockTimeChangeIdentification::is_change(output, spending_tx),
-                        TxOutChangeAnnotation::Change
-                    )
+                    match SpendableTxConstituent::try_new(output) {
+                        Ok(spendable) => matches!(
+                            NLockTimeChangeIdentification::is_change(spendable, spending_tx),
+                            TxOutChangeAnnotation::Change
+                        ),
+                        Err(_) => false, // OP_RETURN outputs cannot be change
+                    }
                 }
                 None => false, // Unspent output: not change by fingerprint
             };

--- a/src/crates/heuristics/src/ast/uih.rs
+++ b/src/crates/heuristics/src/ast/uih.rs
@@ -12,7 +12,10 @@ use tx_indexer_pipeline::{
     node::{Node, NodeId},
     value::{TxMask, TxOutSet, TxSet},
 };
-use tx_indexer_primitives::unified::{AnyOutId, AnyTxId};
+use tx_indexer_primitives::{
+    traits::abstract_types::HasScriptPubkey,
+    unified::{AnyOutId, AnyTxId},
+};
 
 use crate::uih::UnnecessaryInputHeuristic;
 
@@ -45,7 +48,11 @@ impl Node for UnnecessaryInputHeuristic1Node {
         for tx_id in &tx_ids {
             let tx = tx_id.with(ctx.unified_storage());
 
-            let outputs: Vec<_> = tx.outputs().map(|o| (o.id(), o.value())).collect();
+            let outputs: Vec<_> = tx
+                .outputs()
+                .filter(|o| !o.is_op_return())
+                .map(|o| (o.id(), o.value()))
+                .collect();
             if outputs.is_empty() {
                 continue;
             }
@@ -139,7 +146,7 @@ mod tests {
     use tx_indexer_primitives::{
         UnifiedStorage,
         loose::{LooseIndexBuilder, TxId, TxOutId},
-        test_utils::DummyTxData,
+        test_utils::{DummyTxData, DummyTxOutData},
         traits::abstract_types::AbstractTransaction,
         unified::{AnyOutId, AnyTxId},
     };
@@ -196,6 +203,22 @@ mod tests {
             Arc::new(DummyTxData::new_with_spent(
                 vec![50, 50],
                 vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+            )),
+        ]
+    }
+
+    fn setup_uih1_op_return_value_zero_fixture() -> Vec<Arc<dyn AbstractTransaction + Send + Sync>>
+    {
+        vec![
+            Arc::new(DummyTxData::new_with_amounts(vec![100])),
+            Arc::new(DummyTxData::new_with_amounts(vec![200])),
+            Arc::new(DummyTxData::new(
+                vec![
+                    DummyTxOutData::new(150, 0),
+                    DummyTxOutData::new_with_script(0, 1, vec![0x6a, 0x04, 0xde, 0xad, 0xbe, 0xef]),
+                ],
+                vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+                0,
             )),
         ]
     }
@@ -270,6 +293,22 @@ mod tests {
         assert!(
             result.is_empty(),
             "UIH1 should be empty when min(out) >= min(in)"
+        );
+    }
+
+    #[test]
+    fn test_uih1_ignores_op_return() {
+        let all_txs = setup_uih1_op_return_value_zero_fixture();
+        let ctx = Arc::new(PipelineContext::new());
+        let mut engine = engine_with_loose(ctx.clone(), all_txs);
+
+        let source = AllLooseTxs::new(&ctx);
+        let uih1 = UnnecessaryInputHeuristic1::new(source.txs());
+        let result = engine.eval(&uih1);
+
+        assert!(
+            result.is_empty(),
+            "UIH1 must not classify an OP_RETURN value=0 as a change candidate"
         );
     }
 

--- a/src/crates/heuristics/src/ast/uih.rs
+++ b/src/crates/heuristics/src/ast/uih.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashSet;
 
+use bitcoin::Amount;
 use tx_indexer_pipeline::{
     engine::EvalContext,
     expr::Expr,
@@ -13,7 +14,7 @@ use tx_indexer_pipeline::{
     value::{TxMask, TxOutSet, TxSet},
 };
 use tx_indexer_primitives::{
-    traits::abstract_types::HasScriptPubkey,
+    traits::abstract_types::{EnumerateInputValueInArbitraryOrder, HasScriptPubkey},
     unified::{AnyOutId, AnyTxId},
 };
 
@@ -50,14 +51,18 @@ impl Node for UnnecessaryInputHeuristic1Node {
 
             let outputs: Vec<_> = tx
                 .outputs()
-                .filter(|o| !o.is_op_return())
+                .filter(|o| o.is_spendable())
                 .map(|o| (o.id(), o.value()))
                 .collect();
-            if outputs.is_empty() {
+            let Some(min_out) = outputs.iter().map(|(_, v)| *v).min() else {
                 continue;
-            }
+            };
+            let Some(min_in) = tx.input_values().min() else {
+                continue;
+            };
 
-            if let Some(min_out) = UnnecessaryInputHeuristic::uih1_min_output_value(&tx) {
+            if let Some(min_out) = UnnecessaryInputHeuristic::uih1_min_output_value(min_in, min_out)
+            {
                 for (out_id, v) in &outputs {
                     if *v == min_out {
                         result.insert(*out_id);
@@ -115,7 +120,24 @@ impl Node for UnnecessaryInputHeuristic2Node {
         for tx_id in &tx_ids {
             let tx = tx_id.with(ctx.unified_storage());
 
-            result.insert(*tx_id, UnnecessaryInputHeuristic::is_uih2(&tx));
+            let input_values: Vec<Amount> = tx.input_values().collect();
+            let output_values: Vec<Amount> = tx
+                .outputs()
+                .filter(|o| o.is_spendable())
+                .map(|o| o.value())
+                .collect();
+
+            let flagged = if input_values.len() < 2 || output_values.is_empty() {
+                false
+            } else {
+                let sum_in = input_values.iter().copied().sum();
+                let min_in = input_values.iter().copied().min().expect("len >= 2");
+                let sum_out = output_values.iter().copied().sum();
+                let min_out = output_values.iter().copied().min().expect("non-empty");
+                UnnecessaryInputHeuristic::is_uih2(sum_in, min_in, sum_out, min_out)
+            };
+
+            result.insert(*tx_id, flagged);
         }
 
         result

--- a/src/crates/heuristics/src/change_identification.rs
+++ b/src/crates/heuristics/src/change_identification.rs
@@ -1,6 +1,5 @@
 use tx_indexer_primitives::{
-    handle::TxHandle,
-    output_type::OutputType,
+    handle::{SpendableTxConstituent, TxHandle},
     traits::abstract_types::{HasNLockTime, HasScriptPubkey, OutputCount, TxConstituent},
 };
 
@@ -10,19 +9,15 @@ pub enum TxOutChangeAnnotation {
     NotChange,
 }
 
-pub struct NaiveChangeIdentificationHueristic;
+pub struct NaiveChangeIdentificationHeuristic;
 
-impl NaiveChangeIdentificationHueristic {
+impl NaiveChangeIdentificationHeuristic {
     /// Check if a txout is change based on its containing transaction.
-    /// OP_RETURN outputs are never considered change.
-    pub fn is_change<T>(txout: T) -> TxOutChangeAnnotation
+    /// Accepts only spendable outputs; the type system rules OP_RETURN out.
+    pub fn is_change<T>(txout: SpendableTxConstituent<T>) -> TxOutChangeAnnotation
     where
-        T: TxConstituent<Handle: OutputCount> + HasScriptPubkey,
+        T: TxConstituent<Handle: OutputCount>,
     {
-        if txout.is_op_return() {
-            return TxOutChangeAnnotation::NotChange;
-        }
-
         let tx = txout.containing_tx();
         if tx.output_count() > 0 && txout.vout() == tx.output_count() - 1 {
             TxOutChangeAnnotation::Change
@@ -36,15 +31,14 @@ pub struct NLockTimeChangeIdentification;
 
 impl NLockTimeChangeIdentification {
     /// Check if a txout is change based on nLockTime comparison.
-    /// OP_RETURN outputs are never considered change.
-    pub fn is_change<T>(tx_out: T, spending_tx: impl HasNLockTime) -> TxOutChangeAnnotation
+    /// Accepts only spendable outputs; the type system rules OP_RETURN out.
+    pub fn is_change<T>(
+        tx_out: SpendableTxConstituent<T>,
+        spending_tx: impl HasNLockTime,
+    ) -> TxOutChangeAnnotation
     where
-        T: TxConstituent<Handle: HasNLockTime> + HasScriptPubkey,
+        T: TxConstituent<Handle: HasNLockTime>,
     {
-        if tx_out.is_op_return() {
-            return TxOutChangeAnnotation::NotChange;
-        }
-
         let containing_tx_n_locktime = tx_out.containing_tx().n_locktime();
         let child_tx_n_locktime = spending_tx.n_locktime();
         if containing_tx_n_locktime == 0 && child_tx_n_locktime == 0 {
@@ -71,15 +65,11 @@ impl ScriptTypesMatchingChangeIdentification {
     /// types, unresolved prevouts, or multiple matching outputs are all treated
     /// as inconclusive and return `NotChange`.
     ///
-    /// OP_RETURN outputs are never considered change.
-    pub fn is_change<'a, T>(tx_out: T) -> TxOutChangeAnnotation
+    /// Accepts only spendable outputs; the type system rules OP_RETURN out.
+    pub fn is_change<'a, T>(tx_out: SpendableTxConstituent<T>) -> TxOutChangeAnnotation
     where
-        T: TxConstituent<Handle = TxHandle<'a>> + HasScriptPubkey,
+        T: TxConstituent<Handle = TxHandle<'a>>,
     {
-        if tx_out.is_op_return() {
-            return TxOutChangeAnnotation::NotChange;
-        }
-
         let tx = tx_out.containing_tx();
         let mut input_types = tx.inputs().map(|input| input.output_type());
 
@@ -96,17 +86,19 @@ impl ScriptTypesMatchingChangeIdentification {
             return TxOutChangeAnnotation::NotChange;
         }
 
-        let matching_outputs: Vec<usize> = tx
+        let mut matching = tx
             .outputs()
-            .enumerate()
-            .filter_map(|(index, output)| {
-                let out_type = output.output_type();
-                // Skip OP_RETURN outputs when looking for change candidates
-                (out_type == input_type && out_type != OutputType::OpReturn).then_some(index)
-            })
-            .collect();
+            .filter_map(|o| SpendableTxConstituent::try_new(o).ok())
+            .filter(|spendable| spendable.output_type() == input_type);
 
-        if matching_outputs.len() == 1 && matching_outputs[0] == tx_out.vout() {
+        let Some(only) = matching.next() else {
+            return TxOutChangeAnnotation::NotChange;
+        };
+        if matching.next().is_some() {
+            return TxOutChangeAnnotation::NotChange;
+        }
+
+        if only.vout() as usize == tx_out.vout() {
             TxOutChangeAnnotation::Change
         } else {
             TxOutChangeAnnotation::NotChange
@@ -151,8 +143,9 @@ mod tests {
             vout: 0,
             containing_tx: DummyTxData::new_with_amounts(vec![100]),
         };
+        let spendable = SpendableTxConstituent::try_new(txout).ok().unwrap();
         assert_eq!(
-            NaiveChangeIdentificationHueristic::is_change(txout),
+            NaiveChangeIdentificationHeuristic::is_change(spendable),
             TxOutChangeAnnotation::Change
         );
     }
@@ -164,8 +157,9 @@ mod tests {
             containing_tx: DummyTxData::new_with_amounts(vec![100]),
         };
         let spending_tx = DummyTxData::new_with_amounts(vec![100]);
+        let spendable = SpendableTxConstituent::try_new(tx_out).ok().unwrap();
         assert_eq!(
-            NLockTimeChangeIdentification::is_change(tx_out, spending_tx),
+            NLockTimeChangeIdentification::is_change(spendable, spending_tx),
             TxOutChangeAnnotation::NotChange
         );
 
@@ -175,8 +169,9 @@ mod tests {
             containing_tx: DummyTxData::new(vec![DummyTxOutData::new(100, 0)], vec![], 1),
         };
         let spending_tx = DummyTxData::new(vec![DummyTxOutData::new(100, 0)], vec![], 1);
+        let spendable = SpendableTxConstituent::try_new(tx_out).ok().unwrap();
         assert_eq!(
-            NLockTimeChangeIdentification::is_change(tx_out, spending_tx),
+            NLockTimeChangeIdentification::is_change(spendable, spending_tx),
             TxOutChangeAnnotation::Change
         );
     }
@@ -221,11 +216,15 @@ mod tests {
         let change = AnyOutId::from(TxOutId::new(TxId(3), 1)).with(&storage);
 
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(payment),
+            ScriptTypesMatchingChangeIdentification::is_change(
+                SpendableTxConstituent::try_new(payment).ok().unwrap()
+            ),
             TxOutChangeAnnotation::NotChange
         );
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(change),
+            ScriptTypesMatchingChangeIdentification::is_change(
+                SpendableTxConstituent::try_new(change).ok().unwrap()
+            ),
             TxOutChangeAnnotation::Change
         );
     }
@@ -270,11 +269,15 @@ mod tests {
         let change = AnyOutId::from(TxOutId::new(TxId(3), 1)).with(&storage);
 
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(payment),
+            ScriptTypesMatchingChangeIdentification::is_change(
+                SpendableTxConstituent::try_new(payment).ok().unwrap()
+            ),
             TxOutChangeAnnotation::NotChange
         );
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(change),
+            ScriptTypesMatchingChangeIdentification::is_change(
+                SpendableTxConstituent::try_new(change).ok().unwrap()
+            ),
             TxOutChangeAnnotation::NotChange
         );
     }
@@ -301,7 +304,7 @@ mod tests {
                         0,
                         vec![0x6a, 0x04, 0x48, 0x65, 0x6c, 0x6c], // OP_RETURN "Hell"
                     ),
-                    // P2PKH output - should be considered change since it's the only spendable P2PKH
+                    // P2PKH output - the only spendable P2PKH, so it's change
                     DummyTxOutData::new_with_script(
                         249,
                         1,
@@ -316,27 +319,25 @@ mod tests {
         let op_return_output = AnyOutId::from(TxOutId::new(TxId(3), 0)).with(&storage);
         let p2pkh_output = AnyOutId::from(TxOutId::new(TxId(3), 1)).with(&storage);
 
-        // OP_RETURN should never be classified as change
-        assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(op_return_output),
-            TxOutChangeAnnotation::NotChange
-        );
+        // OP_RETURN cannot be wrapped in SpendableTxConstituent -- type system rejects it
+        assert!(SpendableTxConstituent::try_new(op_return_output).is_err());
 
-        // P2PKH output should be change since it's the only spendable output matching input type
+        // P2PKH output is change since it's the only spendable output matching input type
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(p2pkh_output),
+            ScriptTypesMatchingChangeIdentification::is_change(
+                SpendableTxConstituent::try_new(p2pkh_output).ok().unwrap()
+            ),
             TxOutChangeAnnotation::Change
         );
     }
 
     #[test]
-    fn test_all_heuristics_filter_op_return() {
-        // Create an OP_RETURN output to test that all heuristics filter it out
+    fn test_op_return_cannot_be_wrapped() {
+        // The type system enforces OP_RETURN exclusion at the wrapper boundary,
+        // so heuristics never have to check for it themselves.
         let op_return_script = vec![0x6a, 0x04, 0x48, 0x65, 0x6c, 0x6c]; // OP_RETURN "Hell"
-
-        // Test NaiveChangeIdentificationHueristic with OP_RETURN as last output
         let txout_op_return = DummyTxOut {
-            vout: 1, // Last output in a 2-output tx
+            vout: 1,
             containing_tx: DummyTxData::new(
                 vec![
                     DummyTxOutData::new_with_script(
@@ -344,37 +345,13 @@ mod tests {
                         0,
                         script_from_address("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"),
                     ),
-                    DummyTxOutData::new_with_script(0, 1, op_return_script.clone()),
+                    DummyTxOutData::new_with_script(0, 1, op_return_script),
                 ],
                 vec![],
                 0,
             ),
         };
-        // Even though it's the last output, OP_RETURN should not be change
-        assert_eq!(
-            NaiveChangeIdentificationHueristic::is_change(txout_op_return),
-            TxOutChangeAnnotation::NotChange
-        );
-
-        // Test NLockTimeChangeIdentification with OP_RETURN
-        let tx_out_op_return = DummyTxOut {
-            vout: 0,
-            containing_tx: DummyTxData::new(
-                vec![DummyTxOutData::new_with_script(
-                    0,
-                    0,
-                    op_return_script.clone(),
-                )],
-                vec![],
-                1, // Non-zero locktime
-            ),
-        };
-        let spending_tx = DummyTxData::new(vec![], vec![], 1); // Same locktime
-        // Even with matching locktimes, OP_RETURN should not be change
-        assert_eq!(
-            NLockTimeChangeIdentification::is_change(tx_out_op_return, spending_tx),
-            TxOutChangeAnnotation::NotChange
-        );
+        assert!(SpendableTxConstituent::try_new(txout_op_return).is_err());
     }
 
     #[test]
@@ -414,11 +391,15 @@ mod tests {
         let output1 = AnyOutId::from(TxOutId::new(TxId(3), 1)).with(&storage);
 
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(output0),
+            ScriptTypesMatchingChangeIdentification::is_change(
+                SpendableTxConstituent::try_new(output0).ok().unwrap()
+            ),
             TxOutChangeAnnotation::NotChange
         );
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(output1),
+            ScriptTypesMatchingChangeIdentification::is_change(
+                SpendableTxConstituent::try_new(output1).ok().unwrap()
+            ),
             TxOutChangeAnnotation::NotChange
         );
     }

--- a/src/crates/heuristics/src/change_identification.rs
+++ b/src/crates/heuristics/src/change_identification.rs
@@ -1,5 +1,6 @@
 use tx_indexer_primitives::{
     handle::TxHandle,
+    output_type::OutputType,
     traits::abstract_types::{HasNLockTime, HasScriptPubkey, OutputCount, TxConstituent},
 };
 
@@ -13,7 +14,15 @@ pub struct NaiveChangeIdentificationHueristic;
 
 impl NaiveChangeIdentificationHueristic {
     /// Check if a txout is change based on its containing transaction.
-    pub fn is_change(txout: impl TxConstituent<Handle: OutputCount>) -> TxOutChangeAnnotation {
+    /// OP_RETURN outputs are never considered change.
+    pub fn is_change<T>(txout: T) -> TxOutChangeAnnotation
+    where
+        T: TxConstituent<Handle: OutputCount> + HasScriptPubkey,
+    {
+        if txout.is_op_return() {
+            return TxOutChangeAnnotation::NotChange;
+        }
+
         let tx = txout.containing_tx();
         if tx.output_count() > 0 && txout.vout() == tx.output_count() - 1 {
             TxOutChangeAnnotation::Change
@@ -26,10 +35,16 @@ impl NaiveChangeIdentificationHueristic {
 pub struct NLockTimeChangeIdentification;
 
 impl NLockTimeChangeIdentification {
-    pub fn is_change(
-        tx_out: impl TxConstituent<Handle: HasNLockTime>,
-        spending_tx: impl HasNLockTime,
-    ) -> TxOutChangeAnnotation {
+    /// Check if a txout is change based on nLockTime comparison.
+    /// OP_RETURN outputs are never considered change.
+    pub fn is_change<T>(tx_out: T, spending_tx: impl HasNLockTime) -> TxOutChangeAnnotation
+    where
+        T: TxConstituent<Handle: HasNLockTime> + HasScriptPubkey,
+    {
+        if tx_out.is_op_return() {
+            return TxOutChangeAnnotation::NotChange;
+        }
+
         let containing_tx_n_locktime = tx_out.containing_tx().n_locktime();
         let child_tx_n_locktime = spending_tx.n_locktime();
         if containing_tx_n_locktime == 0 && child_tx_n_locktime == 0 {
@@ -55,9 +70,16 @@ impl ScriptTypesMatchingChangeIdentification {
     /// This applies the address-type heuristic conservatively: mixed input
     /// types, unresolved prevouts, or multiple matching outputs are all treated
     /// as inconclusive and return `NotChange`.
-    pub fn is_change<'a>(
-        tx_out: impl TxConstituent<Handle = TxHandle<'a>>,
-    ) -> TxOutChangeAnnotation {
+    ///
+    /// OP_RETURN outputs are never considered change.
+    pub fn is_change<'a, T>(tx_out: T) -> TxOutChangeAnnotation
+    where
+        T: TxConstituent<Handle = TxHandle<'a>> + HasScriptPubkey,
+    {
+        if tx_out.is_op_return() {
+            return TxOutChangeAnnotation::NotChange;
+        }
+
         let tx = tx_out.containing_tx();
         let mut input_types = tx.inputs().map(|input| input.output_type());
 
@@ -77,7 +99,11 @@ impl ScriptTypesMatchingChangeIdentification {
         let matching_outputs: Vec<usize> = tx
             .outputs()
             .enumerate()
-            .filter_map(|(index, output)| (output.output_type() == input_type).then_some(index))
+            .filter_map(|(index, output)| {
+                let out_type = output.output_type();
+                // Skip OP_RETURN outputs when looking for change candidates
+                (out_type == input_type && out_type != OutputType::OpReturn).then_some(index)
+            })
             .collect();
 
         if matching_outputs.len() == 1 && matching_outputs[0] == tx_out.vout() {
@@ -249,6 +275,104 @@ mod tests {
         );
         assert_eq!(
             ScriptTypesMatchingChangeIdentification::is_change(change),
+            TxOutChangeAnnotation::NotChange
+        );
+    }
+
+    #[test]
+    fn test_script_types_matching_excludes_op_return() {
+        let storage = storage_from_loose_txs(vec![
+            // inputs: P2PKH
+            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_script(
+                100,
+                0,
+                script_from_address("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"),
+            )]),
+            DummyTxData::new_with_outputs(vec![DummyTxOutData::new_with_script(
+                150,
+                0,
+                script_from_address("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2"),
+            )]),
+            DummyTxData::new(
+                vec![
+                    // OP_RETURN output - should never be considered change
+                    DummyTxOutData::new_with_script(
+                        0,
+                        0,
+                        vec![0x6a, 0x04, 0x48, 0x65, 0x6c, 0x6c], // OP_RETURN "Hell"
+                    ),
+                    // P2PKH output - should be considered change since it's the only spendable P2PKH
+                    DummyTxOutData::new_with_script(
+                        249,
+                        1,
+                        script_from_address("1BoatSLRHtKNngkdXEeobR76b53LETtpyT"),
+                    ),
+                ],
+                vec![TxOutId::new(TxId(1), 0), TxOutId::new(TxId(2), 0)],
+                0,
+            ),
+        ]);
+
+        let op_return_output = AnyOutId::from(TxOutId::new(TxId(3), 0)).with(&storage);
+        let p2pkh_output = AnyOutId::from(TxOutId::new(TxId(3), 1)).with(&storage);
+
+        // OP_RETURN should never be classified as change
+        assert_eq!(
+            ScriptTypesMatchingChangeIdentification::is_change(op_return_output),
+            TxOutChangeAnnotation::NotChange
+        );
+
+        // P2PKH output should be change since it's the only spendable output matching input type
+        assert_eq!(
+            ScriptTypesMatchingChangeIdentification::is_change(p2pkh_output),
+            TxOutChangeAnnotation::Change
+        );
+    }
+
+    #[test]
+    fn test_all_heuristics_filter_op_return() {
+        // Create an OP_RETURN output to test that all heuristics filter it out
+        let op_return_script = vec![0x6a, 0x04, 0x48, 0x65, 0x6c, 0x6c]; // OP_RETURN "Hell"
+
+        // Test NaiveChangeIdentificationHueristic with OP_RETURN as last output
+        let txout_op_return = DummyTxOut {
+            vout: 1, // Last output in a 2-output tx
+            containing_tx: DummyTxData::new(
+                vec![
+                    DummyTxOutData::new_with_script(
+                        100,
+                        0,
+                        script_from_address("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"),
+                    ),
+                    DummyTxOutData::new_with_script(0, 1, op_return_script.clone()),
+                ],
+                vec![],
+                0,
+            ),
+        };
+        // Even though it's the last output, OP_RETURN should not be change
+        assert_eq!(
+            NaiveChangeIdentificationHueristic::is_change(txout_op_return),
+            TxOutChangeAnnotation::NotChange
+        );
+
+        // Test NLockTimeChangeIdentification with OP_RETURN
+        let tx_out_op_return = DummyTxOut {
+            vout: 0,
+            containing_tx: DummyTxData::new(
+                vec![DummyTxOutData::new_with_script(
+                    0,
+                    0,
+                    op_return_script.clone(),
+                )],
+                vec![],
+                1, // Non-zero locktime
+            ),
+        };
+        let spending_tx = DummyTxData::new(vec![], vec![], 1); // Same locktime
+        // Even with matching locktimes, OP_RETURN should not be change
+        assert_eq!(
+            NLockTimeChangeIdentification::is_change(tx_out_op_return, spending_tx),
             TxOutChangeAnnotation::NotChange
         );
     }

--- a/src/crates/heuristics/src/change_identification.rs
+++ b/src/crates/heuristics/src/change_identification.rs
@@ -86,19 +86,18 @@ impl ScriptTypesMatchingChangeIdentification {
             return TxOutChangeAnnotation::NotChange;
         }
 
-        let mut matching = tx
+        let matching_indices: Vec<usize> = tx
             .outputs()
-            .filter_map(|o| SpendableTxConstituent::try_new(o).ok())
-            .filter(|spendable| spendable.output_type() == input_type);
+            .enumerate()
+            .filter_map(|(index, output)| (output.output_type() == input_type).then_some(index))
+            .collect();
 
-        let Some(only) = matching.next() else {
-            return TxOutChangeAnnotation::NotChange;
-        };
-        if matching.next().is_some() {
+        // There must be exactly one matching output for it to be considered change
+        if matching_indices.len() != 1 {
             return TxOutChangeAnnotation::NotChange;
         }
 
-        if only.vout() as usize == tx_out.vout() {
+        if matching_indices[0] == tx_out.vout() {
             TxOutChangeAnnotation::Change
         } else {
             TxOutChangeAnnotation::NotChange
@@ -114,7 +113,7 @@ mod tests {
         UnifiedStorage,
         loose::LooseIndexBuilder,
         loose::{TxId, TxOutId},
-        test_utils::{DummyTxData, DummyTxOut, DummyTxOutData},
+        test_utils::{DUMMY_UNSPENDABLE_SCRIPT, DummyTxData, DummyTxOut, DummyTxOutData},
         unified::AnyOutId,
     };
 
@@ -143,7 +142,7 @@ mod tests {
             vout: 0,
             containing_tx: DummyTxData::new_with_amounts(vec![100]),
         };
-        let spendable = SpendableTxConstituent::try_new(txout).ok().unwrap();
+        let spendable: SpendableTxConstituent<_> = txout.try_into().unwrap();
         assert_eq!(
             NaiveChangeIdentificationHeuristic::is_change(spendable),
             TxOutChangeAnnotation::Change
@@ -157,7 +156,7 @@ mod tests {
             containing_tx: DummyTxData::new_with_amounts(vec![100]),
         };
         let spending_tx = DummyTxData::new_with_amounts(vec![100]);
-        let spendable = SpendableTxConstituent::try_new(tx_out).ok().unwrap();
+        let spendable: SpendableTxConstituent<_> = tx_out.try_into().unwrap();
         assert_eq!(
             NLockTimeChangeIdentification::is_change(spendable, spending_tx),
             TxOutChangeAnnotation::NotChange
@@ -169,7 +168,7 @@ mod tests {
             containing_tx: DummyTxData::new(vec![DummyTxOutData::new(100, 0)], vec![], 1),
         };
         let spending_tx = DummyTxData::new(vec![DummyTxOutData::new(100, 0)], vec![], 1);
-        let spendable = SpendableTxConstituent::try_new(tx_out).ok().unwrap();
+        let spendable: SpendableTxConstituent<_> = tx_out.try_into().unwrap();
         assert_eq!(
             NLockTimeChangeIdentification::is_change(spendable, spending_tx),
             TxOutChangeAnnotation::Change
@@ -216,15 +215,11 @@ mod tests {
         let change = AnyOutId::from(TxOutId::new(TxId(3), 1)).with(&storage);
 
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(
-                SpendableTxConstituent::try_new(payment).ok().unwrap()
-            ),
+            ScriptTypesMatchingChangeIdentification::is_change(payment.try_into().unwrap()),
             TxOutChangeAnnotation::NotChange
         );
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(
-                SpendableTxConstituent::try_new(change).ok().unwrap()
-            ),
+            ScriptTypesMatchingChangeIdentification::is_change(change.try_into().unwrap()),
             TxOutChangeAnnotation::Change
         );
     }
@@ -269,15 +264,11 @@ mod tests {
         let change = AnyOutId::from(TxOutId::new(TxId(3), 1)).with(&storage);
 
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(
-                SpendableTxConstituent::try_new(payment).ok().unwrap()
-            ),
+            ScriptTypesMatchingChangeIdentification::is_change(payment.try_into().unwrap()),
             TxOutChangeAnnotation::NotChange
         );
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(
-                SpendableTxConstituent::try_new(change).ok().unwrap()
-            ),
+            ScriptTypesMatchingChangeIdentification::is_change(change.try_into().unwrap()),
             TxOutChangeAnnotation::NotChange
         );
     }
@@ -299,11 +290,7 @@ mod tests {
             DummyTxData::new(
                 vec![
                     // OP_RETURN output - should never be considered change
-                    DummyTxOutData::new_with_script(
-                        0,
-                        0,
-                        vec![0x6a, 0x04, 0x48, 0x65, 0x6c, 0x6c], // OP_RETURN "Hell"
-                    ),
+                    DummyTxOutData::new_with_script(0, 0, vec![0x6a, 0x04, 0xde, 0xad, 0xbe, 0xef]),
                     // P2PKH output - the only spendable P2PKH, so it's change
                     DummyTxOutData::new_with_script(
                         249,
@@ -320,23 +307,20 @@ mod tests {
         let p2pkh_output = AnyOutId::from(TxOutId::new(TxId(3), 1)).with(&storage);
 
         // OP_RETURN cannot be wrapped in SpendableTxConstituent -- type system rejects it
-        assert!(SpendableTxConstituent::try_new(op_return_output).is_err());
+        assert!(TryInto::<SpendableTxConstituent<_>>::try_into(op_return_output).is_err());
 
         // P2PKH output is change since it's the only spendable output matching input type
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(
-                SpendableTxConstituent::try_new(p2pkh_output).ok().unwrap()
-            ),
+            ScriptTypesMatchingChangeIdentification::is_change(p2pkh_output.try_into().unwrap()),
             TxOutChangeAnnotation::Change
         );
     }
 
     #[test]
-    fn test_op_return_cannot_be_wrapped() {
-        // The type system enforces OP_RETURN exclusion at the wrapper boundary,
+    fn test_unspendable_cannot_be_wrapped() {
+        // The type system enforces unspendable output exclusion at the wrapper boundary,
         // so heuristics never have to check for it themselves.
-        let op_return_script = vec![0x6a, 0x04, 0x48, 0x65, 0x6c, 0x6c]; // OP_RETURN "Hell"
-        let txout_op_return = DummyTxOut {
+        let txout_unspendable = DummyTxOut {
             vout: 1,
             containing_tx: DummyTxData::new(
                 vec![
@@ -345,13 +329,13 @@ mod tests {
                         0,
                         script_from_address("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"),
                     ),
-                    DummyTxOutData::new_with_script(0, 1, op_return_script),
+                    DummyTxOutData::new_with_script(0, 1, DUMMY_UNSPENDABLE_SCRIPT),
                 ],
                 vec![],
                 0,
             ),
         };
-        assert!(SpendableTxConstituent::try_new(txout_op_return).is_err());
+        assert!(TryInto::<SpendableTxConstituent<_>>::try_into(txout_unspendable).is_err());
     }
 
     #[test]
@@ -391,15 +375,11 @@ mod tests {
         let output1 = AnyOutId::from(TxOutId::new(TxId(3), 1)).with(&storage);
 
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(
-                SpendableTxConstituent::try_new(output0).ok().unwrap()
-            ),
+            ScriptTypesMatchingChangeIdentification::is_change(output0.try_into().unwrap()),
             TxOutChangeAnnotation::NotChange
         );
         assert_eq!(
-            ScriptTypesMatchingChangeIdentification::is_change(
-                SpendableTxConstituent::try_new(output1).ok().unwrap()
-            ),
+            ScriptTypesMatchingChangeIdentification::is_change(output1.try_into().unwrap()),
             TxOutChangeAnnotation::NotChange
         );
     }

--- a/src/crates/heuristics/src/uih.rs
+++ b/src/crates/heuristics/src/uih.rs
@@ -1,17 +1,24 @@
 use bitcoin::Amount;
 use tx_indexer_primitives::traits::abstract_types::{
-    EnumerateInputValueInArbitraryOrder, EnumerateOutputValueInArbitraryOrder,
+    AbstractTransaction, EnumerateInputValueInArbitraryOrder,
 };
 
 pub struct UnnecessaryInputHeuristic;
 
 impl UnnecessaryInputHeuristic {
+    /// Minimum output value among spendable outputs, when it is less than the
+    /// minimum input value. OP_RETURN outputs are excluded since they cannot be
+    /// spent and including them (often value=0) would always trip UIH1.
     pub fn uih1_min_output_value<T>(tx: &T) -> Option<Amount>
     where
-        T: EnumerateInputValueInArbitraryOrder + EnumerateOutputValueInArbitraryOrder,
+        T: EnumerateInputValueInArbitraryOrder + AbstractTransaction,
     {
         let input_values: Vec<Amount> = tx.input_values().collect();
-        let output_values: Vec<Amount> = tx.output_values().collect();
+        let output_values: Vec<Amount> = tx
+            .outputs()
+            .filter(|o| !o.is_op_return())
+            .map(|o| o.value())
+            .collect();
 
         if input_values.is_empty() || output_values.is_empty() {
             return None;
@@ -37,10 +44,14 @@ impl UnnecessaryInputHeuristic {
 
     pub fn is_uih2<T>(tx: &T) -> bool
     where
-        T: EnumerateInputValueInArbitraryOrder + EnumerateOutputValueInArbitraryOrder,
+        T: EnumerateInputValueInArbitraryOrder + AbstractTransaction,
     {
         let input_values: Vec<Amount> = tx.input_values().collect();
-        let output_values: Vec<Amount> = tx.output_values().collect();
+        let output_values: Vec<Amount> = tx
+            .outputs()
+            .filter(|o| !o.is_op_return())
+            .map(|o| o.value())
+            .collect();
 
         if input_values.len() < 2 || output_values.is_empty() {
             return false;

--- a/src/crates/heuristics/src/uih.rs
+++ b/src/crates/heuristics/src/uih.rs
@@ -1,69 +1,20 @@
 use bitcoin::Amount;
-use tx_indexer_primitives::traits::abstract_types::{
-    AbstractTransaction, EnumerateInputValueInArbitraryOrder,
-};
 
 pub struct UnnecessaryInputHeuristic;
 
 impl UnnecessaryInputHeuristic {
-    /// Minimum output value among spendable outputs, when it is less than the
-    /// minimum input value. OP_RETURN outputs are excluded since they cannot be
-    /// spent and including them (often value=0) would always trip UIH1.
-    pub fn uih1_min_output_value<T>(tx: &T) -> Option<Amount>
-    where
-        T: EnumerateInputValueInArbitraryOrder + AbstractTransaction,
-    {
-        let input_values: Vec<Amount> = tx.input_values().collect();
-        let output_values: Vec<Amount> = tx
-            .outputs()
-            .filter(|o| !o.is_op_return())
-            .map(|o| o.value())
-            .collect();
-
-        if input_values.is_empty() || output_values.is_empty() {
-            return None;
-        }
-
-        let min_in = input_values
-            .iter()
-            .min()
-            .copied()
-            .expect("non-empty inputs");
-        let min_out = output_values
-            .iter()
-            .min()
-            .copied()
-            .expect("non-empty outputs");
-
-        if min_out < min_in {
-            Some(min_out)
-        } else {
-            None
-        }
+    /// UIH1 (Optimal change): the smallest output is likely change when it is
+    /// strictly less than the smallest input. Returns `Some(min_out)` in that
+    /// case. Caller is responsible for excluding unspendable outputs from
+    /// `min_out` — including them (often value=0) would always trip UIH1.
+    pub fn uih1_min_output_value(min_in: Amount, min_out: Amount) -> Option<Amount> {
+        (min_out < min_in).then_some(min_out)
     }
 
-    pub fn is_uih2<T>(tx: &T) -> bool
-    where
-        T: EnumerateInputValueInArbitraryOrder + AbstractTransaction,
-    {
-        let input_values: Vec<Amount> = tx.input_values().collect();
-        let output_values: Vec<Amount> = tx
-            .outputs()
-            .filter(|o| !o.is_op_return())
-            .map(|o| o.value())
-            .collect();
-
-        if input_values.len() < 2 || output_values.is_empty() {
-            return false;
-        }
-
-        let sum_in = input_values.iter().fold(Amount::from_sat(0), |a, b| a + *b);
-        let min_in = input_values.iter().min().copied().expect("len >= 2");
-        let sum_out = output_values
-            .iter()
-            .fold(Amount::from_sat(0), |a, b| a + *b);
-        let min_out = output_values.iter().min().copied().expect("non-empty");
-
+    /// UIH2 (Unnecessary input): the largest output could be paid without the
+    /// smallest input. Caller is responsible for excluding unspendable outputs
+    /// from the sum/min and ensuring there are at least two inputs.
+    pub fn is_uih2(sum_in: Amount, min_in: Amount, sum_out: Amount, min_out: Amount) -> bool {
         (sum_in - min_in) >= (sum_out - min_out)
     }
 }

--- a/src/crates/primitives/src/handle.rs
+++ b/src/crates/primitives/src/handle.rs
@@ -311,3 +311,37 @@ impl<'a> TxConstituent for TxOutHandle<'a> {
         self.vout() as usize
     }
 }
+
+/// Wrapper guaranteeing the inner value is a spendable output (not OP_RETURN).
+///
+/// Construct via [`SpendableTxConstituent::try_new`]: `Ok` for spendable outputs,
+/// `Err` returns the original value back so callers can handle the unspendable
+/// case explicitly. Heuristics that consume `SpendableTxConstituent<T>` no
+/// longer need their own OP_RETURN check — the type system enforces it at the
+/// call boundary.
+pub struct SpendableTxConstituent<T>(T);
+
+impl<T: HasScriptPubkey> SpendableTxConstituent<T> {
+    /// Wraps `value` if it is spendable; returns it back as `Err` if OP_RETURN.
+    pub fn try_new(value: T) -> Result<Self, T> {
+        if value.is_op_return() {
+            Err(value)
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+impl<T> SpendableTxConstituent<T> {
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> std::ops::Deref for SpendableTxConstituent<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}

--- a/src/crates/primitives/src/handle.rs
+++ b/src/crates/primitives/src/handle.rs
@@ -65,6 +65,14 @@ pub struct TxOutHandle<'a> {
     pub(crate) index: &'a dyn IndexedGraph,
 }
 
+impl<'a> std::fmt::Debug for TxOutHandle<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TxOutHandle")
+            .field("out_id", &self.out_id)
+            .finish()
+    }
+}
+
 impl<'a> TxOutHandle<'a> {
     pub fn id(&self) -> AnyOutId {
         self.out_id
@@ -316,19 +324,25 @@ impl<'a> TxConstituent for TxOutHandle<'a> {
 ///
 /// Construct via [`SpendableTxConstituent::try_new`]: `Ok` for spendable outputs,
 /// `Err` returns the original value back so callers can handle the unspendable
-/// case explicitly. Heuristics that consume `SpendableTxConstituent<T>` no
-/// longer need their own OP_RETURN check — the type system enforces it at the
-/// call boundary.
+/// case explicitly.
 pub struct SpendableTxConstituent<T>(T);
 
 impl<T: HasScriptPubkey> SpendableTxConstituent<T> {
-    /// Wraps `value` if it is spendable; returns it back as `Err` if OP_RETURN.
+    /// Wraps `value` if it is spendable; returns it back as `Err` if unspendable.
     pub fn try_new(value: T) -> Result<Self, T> {
-        if value.is_op_return() {
-            Err(value)
-        } else {
+        if value.is_spendable() {
             Ok(Self(value))
+        } else {
+            Err(value)
         }
+    }
+}
+
+impl<'a> TryFrom<TxOutHandle<'a>> for SpendableTxConstituent<TxOutHandle<'a>> {
+    type Error = TxOutHandle<'a>;
+
+    fn try_from(value: TxOutHandle<'a>) -> Result<Self, Self::Error> {
+        Self::try_new(value)
     }
 }
 

--- a/src/crates/primitives/src/test_utils/mod.rs
+++ b/src/crates/primitives/src/test_utils/mod.rs
@@ -247,3 +247,14 @@ impl TxConstituent for DummyTxOut {
         self.vout
     }
 }
+
+impl HasScriptPubkey for DummyTxOut {
+    fn script_pubkey_bytes(&self) -> Vec<u8> {
+        // Get the script pubkey from the corresponding output in the containing transaction
+        self.containing_tx
+            .outputs()
+            .nth(self.vout)
+            .map(|output| output.script_pubkey_bytes())
+            .unwrap_or_default()
+    }
+}

--- a/src/crates/primitives/src/test_utils/mod.rs
+++ b/src/crates/primitives/src/test_utils/mod.rs
@@ -12,6 +12,10 @@ use crate::{
     },
 };
 
+/// Dummy unspendable script for testing - all bits set to 0xFF
+/// This is used instead of real OP_RETURN scripts in tests to mark outputs as unspendable
+pub const DUMMY_UNSPENDABLE_SCRIPT: &[u8] = &[0xFF, 0xFF, 0xFF, 0xFF];
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DummyTxData {
     outputs: Vec<DummyTxOutData>,
@@ -115,6 +119,11 @@ impl DummyTxOutData {
 impl HasScriptPubkey for DummyTxOutData {
     fn script_pubkey_bytes(&self) -> Vec<u8> {
         self.script_pubkey.clone()
+    }
+
+    fn is_spendable(&self) -> bool {
+        // Check for our dummy unspendable script or real OP_RETURN
+        self.script_pubkey != DUMMY_UNSPENDABLE_SCRIPT && !self.is_op_return()
     }
 }
 
@@ -232,6 +241,7 @@ impl From<DummyTxData> for Box<dyn AbstractTransaction + Send + Sync> {
     }
 }
 
+#[derive(Debug)]
 pub struct DummyTxOut {
     pub vout: usize,
     pub containing_tx: DummyTxData,
@@ -256,5 +266,19 @@ impl HasScriptPubkey for DummyTxOut {
             .nth(self.vout)
             .map(|output| output.script_pubkey_bytes())
             .unwrap_or_default()
+    }
+
+    fn is_spendable(&self) -> bool {
+        // Check for our dummy unspendable script or real OP_RETURN
+        let script = self.script_pubkey_bytes();
+        script != DUMMY_UNSPENDABLE_SCRIPT && !self.is_op_return()
+    }
+}
+
+impl TryFrom<DummyTxOut> for crate::handle::SpendableTxConstituent<DummyTxOut> {
+    type Error = DummyTxOut;
+
+    fn try_from(value: DummyTxOut) -> Result<Self, Self::Error> {
+        Self::try_new(value)
     }
 }

--- a/src/crates/primitives/src/traits/abstract_types.rs
+++ b/src/crates/primitives/src/traits/abstract_types.rs
@@ -92,6 +92,10 @@ pub trait HasScriptPubkey {
     fn output_type(&self) -> OutputType {
         classify_script_pubkey(&self.script_pubkey_bytes())
     }
+
+    fn is_op_return(&self) -> bool {
+        self.output_type() == OutputType::OpReturn
+    }
 }
 
 /// Transaction version

--- a/src/crates/primitives/src/traits/abstract_types.rs
+++ b/src/crates/primitives/src/traits/abstract_types.rs
@@ -96,6 +96,11 @@ pub trait HasScriptPubkey {
     fn is_op_return(&self) -> bool {
         self.output_type() == OutputType::OpReturn
     }
+
+    /// Returns true if this output can be spent
+    fn is_spendable(&self) -> bool {
+        !self.is_op_return()
+    }
 }
 
 /// Transaction version


### PR DESCRIPTION
This PR adds filtering for `OP_RETURN` outputs across all change identification heuristics, ensuring that unspendable outputs are never incorrectly identified as change.

closes #64 