### PR TITLE
Return txids as an iterator

### DIFF
--- a/src/crates/pipeline/src/ops/source.rs
+++ b/src/crates/pipeline/src/ops/source.rs
@@ -30,10 +30,7 @@ impl SourceNode for AllLooseTxsNode {
 
     fn evaluate(&self, ctx: &mut SourceNodeEvalContext<'_>) -> HashSet<AnyTxId> {
         let start = ctx.processed_loose_len();
-        ctx.unified_storage
-            .loose_txids_from(start)
-            .into_iter()
-            .collect()
+        ctx.unified_storage.loose_txids_from(start).collect()
     }
 
     fn name(&self) -> &'static str {
@@ -57,10 +54,7 @@ impl SourceNode for AllDenseTxsNode {
 
     fn evaluate(&self, ctx: &mut SourceNodeEvalContext<'_>) -> HashSet<AnyTxId> {
         let start = ctx.processed_dense_len();
-        ctx.unified_storage
-            .dense_txids_from(start)
-            .into_iter()
-            .collect()
+        ctx.unified_storage.dense_txids_from(start).collect()
     }
 
     fn name(&self) -> &'static str {

--- a/src/crates/primitives/src/dense/mod.rs
+++ b/src/crates/primitives/src/dense/mod.rs
@@ -517,15 +517,15 @@ impl DenseStorage {
     }
 
     /// Return all dense TxInIds for the transaction at the given dense TxId.
-    pub fn get_txin_ids(&self, txid: TxId) -> Vec<TxInId> {
+    pub fn get_txin_ids(&self, txid: TxId) -> impl Iterator<Item = TxInId> {
         let (start, end) = self.tx_in_range(txid);
-        (start..end).map(TxInId::new).collect()
+        (start..end).map(TxInId::new)
     }
 
     /// Return all dense TxOutIds for the transaction at the given dense TxId.
-    pub fn get_txout_ids(&self, txid: TxId) -> Vec<TxOutId> {
+    pub fn get_txout_ids(&self, txid: TxId) -> impl Iterator<Item = TxOutId> {
         let (start, end) = self.tx_out_range(txid);
-        (start..end).map(TxOutId::new).collect()
+        (start..end).map(TxOutId::new)
     }
 
     /// Return the first dense TxOutId that uses the given script pubkey hash.

--- a/src/crates/primitives/src/tests.rs
+++ b/src/crates/primitives/src/tests.rs
@@ -53,8 +53,7 @@ mod primitive_tests {
         let total_txs = storage.dense_txids_len();
         assert_eq!(total_txs, (tip_height + 1) as usize);
 
-        let txids = storage.dense_txids_from(0);
-        assert_eq!(txids.len(), total_txs);
+        assert_eq!(storage.dense_txids_from(0).count(), total_txs);
 
         // TODO: parse from genesis to tip and repeat assertions
 
@@ -199,8 +198,8 @@ mod primitive_tests {
                 let dense_id = *dense_id;
                 let tx = storage.get_tx(dense_id);
                 assert!(!tx.is_coinbase());
-                let txin_ids = storage.get_txin_ids(dense_id);
-                let txout_ids = storage.get_txout_ids(dense_id);
+                let txin_ids: Vec<_> = storage.get_txin_ids(dense_id).collect();
+                let txout_ids: Vec<_> = storage.get_txout_ids(dense_id).collect();
                 let (in_start, in_end) = storage.tx_in_range(dense_id);
                 let (out_start, out_end) = storage.tx_out_range(dense_id);
 
@@ -247,7 +246,7 @@ mod primitive_tests {
                     .expect("expected a non-coinbase tx");
                 let dense_id = *dense_id;
                 let tx = storage.get_tx(dense_id);
-                let txin_ids = storage.get_txin_ids(dense_id);
+                let txin_ids: Vec<_> = storage.get_txin_ids(dense_id).collect();
 
                 assert_eq!(txin_ids.len(), tx.input.len());
                 assert_eq!(txin_ids.len(), 1);

--- a/src/crates/primitives/src/unified/mod.rs
+++ b/src/crates/primitives/src/unified/mod.rs
@@ -312,11 +312,11 @@ impl UnifiedStorage {
             .expect("loose txid not found in storage")
     }
 
-    // Returns empty Vec when loose storage is absent
-    pub fn loose_txids(&self) -> Vec<AnyTxId> {
-        self.loose.as_ref().map_or(Vec::new(), |loose| {
-            loose.tx_order.iter().copied().map(AnyTxId::from).collect()
-        })
+    pub fn loose_txids(&self) -> impl Iterator<Item = AnyTxId> + '_ {
+        self.loose
+            .as_ref()
+            .into_iter()
+            .flat_map(|loose| loose.tx_order.iter().copied().map(AnyTxId::from))
     }
 
     pub fn loose_txids_len(&self) -> usize {
@@ -329,33 +329,21 @@ impl UnifiedStorage {
         })
     }
 
-    pub fn loose_txids_from(&self, start: usize) -> Vec<AnyTxId> {
-        self.loose.as_ref().map_or(Vec::new(), |loose| {
-            if start >= loose.tx_order.len() {
-                return Vec::new();
-            }
-            loose.tx_order[start..]
-                .iter()
-                .copied()
-                .map(AnyTxId::from)
-                .collect()
+    pub fn loose_txids_from(&self, start: usize) -> impl Iterator<Item = AnyTxId> + '_ {
+        self.loose.as_ref().into_iter().flat_map(move |loose| {
+            let s = start.min(loose.tx_order.len());
+            loose.tx_order[s..].iter().copied().map(AnyTxId::from)
         })
     }
 
-    pub fn dense_txids_from(&self, start: usize) -> Vec<AnyTxId> {
-        let Some(dense) = self.dense.as_ref() else {
-            // TODO: should panic or this should just be exposed on dense traits
-            return Vec::new();
-        };
-        let total = usize::try_from(dense.tx_count()).expect("dense tx count should fit in usize");
-        if start >= total {
-            // TODO: return error
-            return Vec::new();
-        }
+    pub fn dense_txids_from(&self, start: usize) -> impl Iterator<Item = AnyTxId> {
+        let total = self.dense.as_ref().map_or(0, |dense| {
+            usize::try_from(dense.tx_count()).expect("dense tx count should fit in usize")
+        });
+        let start = start.min(total);
         (start..total)
             .map(|idx| dense::TxId::new(u32::try_from(idx).expect("dense txid should fit in u32")))
             .map(AnyTxId::from)
-            .collect()
     }
 
     pub fn tx_out_ids(&self, txid: AnyTxId) -> Vec<AnyOutId> {
@@ -367,12 +355,7 @@ impl UnifiedStorage {
                     .map(|vout| AnyOutId::from(loose::TxOutId::new(lid, vout as u32)))
                     .collect()
             },
-            |ds, did| {
-                ds.get_txout_ids(did)
-                    .into_iter()
-                    .map(AnyOutId::from)
-                    .collect()
-            },
+            |ds, did| ds.get_txout_ids(did).map(AnyOutId::from).collect(),
         )
     }
 
@@ -467,12 +450,7 @@ impl TxIoIndex for UnifiedStorage {
                     .map(|vin| AnyInId::from(loose::TxInId::new(lid, vin as u32)))
                     .collect()
             },
-            |ds, did| {
-                ds.get_txin_ids(did)
-                    .into_iter()
-                    .map(AnyInId::from)
-                    .collect()
-            },
+            |ds, did| ds.get_txin_ids(did).map(AnyInId::from).collect(),
         )
     }
 


### PR DESCRIPTION
Ids were being redundantly collected and converted to an  iter() later. 
And remove collects() where we can.

cc @0xZaddyy @Mshehu5 @bc1cindy 