### PR TITLE
Avoid deep clone when combining single facts

### DIFF
--- a/src/crates/heuristics/src/ast/uih.rs
+++ b/src/crates/heuristics/src/ast/uih.rs
@@ -370,8 +370,10 @@ mod tests {
         let uih1 = UnnecessaryInputHeuristic1::new(source.txs());
         let uih2 = UnnecessaryInputHeuristic2::new(source.txs());
 
-        let uih1_result = engine.eval(&uih1);
-        let uih2_result = engine.eval(&uih2);
+        // `.into_owned()` because we hold both results simultaneously below;
+        // each `eval` borrows the engine, so we drop the borrows by cloning out.
+        let uih1_result = engine.eval(&uih1).into_owned();
+        let uih2_result = engine.eval(&uih2).into_owned();
 
         assert!(
             uih1_result.contains(&AnyOutId::from(TxOutId::new(TxId(5), 1))),

--- a/src/crates/pipeline/src/engine.rs
+++ b/src/crates/pipeline/src/engine.rs
@@ -6,6 +6,7 @@
 //! - Dependency resolution and topological ordering
 //! - Fixpoint iteration for recursive/cyclic definitions
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -154,9 +155,14 @@ impl Engine {
     /// Evaluate an expression to a single combined value.
     ///
     /// Fetches all facts for the expression from storage and combines them
-    /// using the value type's `combine_facts`. Returns `Default::default()`
-    /// if no facts have been produced (e.g. pipeline not yet run).
-    pub fn eval<T: ExprValue>(&mut self, expr: &Expr<T>) -> T::Output
+    /// using the value type's `combine_facts`. Returns
+    /// `Cow::Owned(Default::default())` if no facts have been produced
+    /// (e.g. pipeline not yet run).
+    ///
+    /// The result is a [`Cow`] so the common single-fact case borrows directly
+    /// from internal storage and avoids deep-cloning potentially huge maps /
+    /// sets / DSUs. Call [`Cow::into_owned`] if you need ownership.
+    pub fn eval<T: ExprValue>(&mut self, expr: &Expr<T>) -> Cow<'_, T::Output>
     where
         T::Output: Default,
     {
@@ -165,9 +171,6 @@ impl Engine {
             .storage
             .non_volatile_get::<T>(expr.id())
             .unwrap_or_default();
-        if facts.is_empty() {
-            return Default::default();
-        }
         T::combine_facts(&facts)
     }
 

--- a/src/crates/pipeline/src/value.rs
+++ b/src/crates/pipeline/src/value.rs
@@ -3,6 +3,7 @@
 //! This module defines the `ExprValue` trait and marker types that represent
 //! different kinds of values that expressions can produce.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -19,9 +20,16 @@ pub trait ExprValue: 'static {
     type Output: Clone + Default + PartialEq + Send + Sync + 'static;
 
     /// Combine multiple facts (e.g. from fixpoint iterations) into a single value.
-    /// Empty slice returns `Default::default()`. Implementations should clone at most
-    /// once (the first fact or accumulator) and merge the rest by reference.
-    fn combine_facts(facts: &[&Self::Output]) -> Self::Output;
+    ///
+    /// The result is returned as a [`Cow`] so that the common single-fact case
+    /// can borrow directly from storage instead of paying for a deep clone of
+    /// what is often a large map/set/DSU. Implementations should:
+    ///
+    /// * return `Cow::Owned(Default::default())` for an empty slice,
+    /// * return `Cow::Borrowed(facts[0])` when exactly one fact is present, and
+    /// * clone at most once (the first fact / accumulator) when merging
+    ///   multiple facts and return `Cow::Owned`.
+    fn combine_facts<'a>(facts: &[&'a Self::Output]) -> Cow<'a, Self::Output>;
 }
 
 // Built-in Value Types
@@ -42,15 +50,18 @@ impl<K> Default for Mask<K> {
 impl<K: Eq + Hash + Clone + Send + Sync + 'static> ExprValue for Mask<K> {
     type Output = HashMap<K, bool>;
 
-    fn combine_facts(facts: &[&Self::Output]) -> Self::Output {
-        if facts.is_empty() {
-            return Default::default();
+    fn combine_facts<'a>(facts: &[&'a Self::Output]) -> Cow<'a, Self::Output> {
+        match facts {
+            [] => Cow::Owned(Default::default()),
+            [single] => Cow::Borrowed(*single),
+            [first, rest @ ..] => {
+                let mut acc = (*first).clone();
+                for next in rest {
+                    acc.extend(next.iter().map(|(k, v)| (k.clone(), *v)));
+                }
+                Cow::Owned(acc)
+            }
         }
-        let mut acc = facts[0].clone();
-        for rest in &facts[1..] {
-            acc.extend(rest.iter().map(|(k, v)| (k.clone(), *v)));
-        }
-        acc
     }
 }
 
@@ -64,18 +75,18 @@ where
 {
     type Output = SparseDisjointSet<T>;
 
-    fn combine_facts(facts: &[&Self::Output]) -> Self::Output {
-        if facts.is_empty() {
-            return Default::default();
+    fn combine_facts<'a>(facts: &[&'a Self::Output]) -> Cow<'a, Self::Output> {
+        match facts {
+            [] => Cow::Owned(Default::default()),
+            [single] => Cow::Borrowed(*single),
+            [first, rest @ ..] => {
+                let mut acc = (*first).clone();
+                for next in rest {
+                    acc = acc.join(next);
+                }
+                Cow::Owned(acc)
+            }
         }
-        if facts.len() == 1 {
-            return facts[0].clone();
-        }
-        let mut acc = facts[0].clone();
-        for next in &facts[1..] {
-            acc = acc.join(next);
-        }
-        acc
     }
 }
 
@@ -86,15 +97,18 @@ pub struct TransactionSet;
 impl ExprValue for TransactionSet {
     type Output = HashSet<AnyTxId>;
 
-    fn combine_facts(facts: &[&Self::Output]) -> Self::Output {
-        if facts.is_empty() {
-            return Default::default();
+    fn combine_facts<'a>(facts: &[&'a Self::Output]) -> Cow<'a, Self::Output> {
+        match facts {
+            [] => Cow::Owned(Default::default()),
+            [single] => Cow::Borrowed(*single),
+            [first, rest @ ..] => {
+                let mut acc = (*first).clone();
+                for next in rest {
+                    acc.extend(next.iter().cloned());
+                }
+                Cow::Owned(acc)
+            }
         }
-        let mut acc = facts[0].clone();
-        for rest in &facts[1..] {
-            acc.extend(rest.iter().cloned());
-        }
-        acc
     }
 }
 
@@ -104,15 +118,18 @@ pub struct TransactionOutSet;
 impl ExprValue for TransactionOutSet {
     type Output = HashSet<AnyOutId>;
 
-    fn combine_facts(facts: &[&Self::Output]) -> Self::Output {
-        if facts.is_empty() {
-            return Default::default();
+    fn combine_facts<'a>(facts: &[&'a Self::Output]) -> Cow<'a, Self::Output> {
+        match facts {
+            [] => Cow::Owned(Default::default()),
+            [single] => Cow::Borrowed(*single),
+            [first, rest @ ..] => {
+                let mut acc = (*first).clone();
+                for next in rest {
+                    acc.extend(next.iter().cloned());
+                }
+                Cow::Owned(acc)
+            }
         }
-        let mut acc = facts[0].clone();
-        for rest in &facts[1..] {
-            acc.extend(rest.iter().cloned());
-        }
-        acc
     }
 }
 


### PR DESCRIPTION
AST nodes return Cow wrapped types so they can just reference node storage  instead of copying or cloning.