### PR TITLE
Fund wallets with random coinbase amounts during universe setup

### DIFF
--- a/btsim/src/blocks.rs
+++ b/btsim/src/blocks.rs
@@ -363,6 +363,18 @@ pub(crate) struct BlockTemplate {
 
 impl<'a> BlockTemplate {
     pub(crate) fn mine(self, rewards_to: AddressId, sim: &'a mut Simulation) -> BlockHandle<'a> {
+        self.mine_with_reward(rewards_to, None, sim)
+    }
+
+    /// Mine a block, optionally overriding the coinbase output amount. `reward_override`
+    /// is used to seed wallets with arbitrary funding amounts during universe setup;
+    /// `None` pays the normal subsidy + fees.
+    pub(crate) fn mine_with_reward(
+        self,
+        rewards_to: AddressId,
+        reward_override: Option<Amount>,
+        sim: &'a mut Simulation,
+    ) -> BlockHandle<'a> {
         let parent_block = self.parent.with(sim);
 
         let height = 1 + parent_block.info().height;
@@ -370,7 +382,7 @@ impl<'a> BlockTemplate {
 
         let fees = self.txs.iter().map(|tx| tx.with(sim).info().fee).sum();
 
-        let block_rewards = subsidy + fees;
+        let block_rewards = reward_override.unwrap_or(subsidy + fees);
 
         let mut confirmed_txs = OrdSet::from(&self.txs);
 

--- a/btsim/src/lib.rs
+++ b/btsim/src/lib.rs
@@ -51,6 +51,10 @@ mod transaction;
 mod tx_contruction;
 mod wallet;
 
+/// Inclusive range (in satoshis) for the random amount funded to each wallet coinbase
+/// during universe setup.
+const WALLET_FUNDING_RANGE_SATS: std::ops::RangeInclusive<u64> = 10_000..=10_000_000;
+
 #[derive(Debug, Clone)]
 struct PrngFactory(Pcg64);
 
@@ -325,16 +329,18 @@ impl<'a> Simulation {
             .map(|&id| id.with_mut(self).new_address())
             .collect::<Vec<_>>();
 
-        // For now we just mine a coinbase transaction for each wallet
+        // For now we just mine a coinbase transaction for each wallet, funding each with a
+        // random amount instead of the full block subsidy so wallets start with varied UTXOs.
         let mut i = 0;
         for address in addresses.iter() {
             for _ in 0..prng.random_range(5..10) {
+                let funding = Amount::from_sat(prng.random_range(WALLET_FUNDING_RANGE_SATS));
                 let _ = BroadcastSetHandleMut {
                     id: BroadcastSetId(i),
                     sim: self,
                 }
                 .construct_block_template(Weight::MAX_BLOCK)
-                .mine(*address, self);
+                .mine_with_reward(*address, Some(funding), self);
 
                 self.assert_invariants();
                 i += 1;


### PR DESCRIPTION
One of the goals of the simulations is to observe which how peers score inputs on the order book. But we don't get meaningful reseults if all inputs at 50 btc coinbases